### PR TITLE
Use `OTU` validation to replace some checks

### DIFF
--- a/ref_builder/otu/isolate.py
+++ b/ref_builder/otu/isolate.py
@@ -6,7 +6,6 @@ from ref_builder.ncbi.models import NCBIGenbank
 from ref_builder.otu.utils import (
     RefSeqConflictError,
     assign_records_to_segments,
-    check_sequence_length,
     fetch_records_from_accessions,
     group_genbank_records_by_isolate,
     parse_refseq_comment,

--- a/ref_builder/otu/isolate.py
+++ b/ref_builder/otu/isolate.py
@@ -160,6 +160,7 @@ def create_isolate(
         otu_name=otu.name,
         otu_id=str(otu.id),
         taxid=otu.taxid,
+        accessions=[record.accession for record in records],
     )
 
     try:

--- a/ref_builder/otu/isolate.py
+++ b/ref_builder/otu/isolate.py
@@ -174,25 +174,6 @@ def create_isolate(
 
         return None
 
-    for segment_id, record in assigned.items():
-        matching_segment = otu.plan.get_segment_by_id(segment_id)
-
-        if not check_sequence_length(
-            record.sequence,
-            matching_segment.length,
-            matching_segment.length_tolerance,
-        ):
-            log.debug(
-                "Sequence does not conform to plan length.",
-                accession=record.accession_version,
-                length=len(record.sequence),
-                segment=(matching_segment.name, matching_segment.id),
-                required_length=matching_segment.length,
-                tolerance=matching_segment.length_tolerance,
-            )
-
-            return None
-
     try:
         isolate = repo.create_isolate(
             otu.id,

--- a/ref_builder/otu/isolate.py
+++ b/ref_builder/otu/isolate.py
@@ -174,18 +174,11 @@ def create_isolate(
 
         return None
 
-    try:
-        isolate = repo.create_isolate(
-            otu.id,
-            legacy_id=None,
-            name=isolate_name,
-        )
-    except ValueError as e:
-        if "Isolate name already exists" in str(e):
-            log.debug("OTU already contains isolate with name.")
-            return None
-
-        raise
+    isolate = repo.create_isolate(
+        otu.id,
+        legacy_id=None,
+        name=isolate_name,
+    )
 
     for segment_id, record in assigned.items():
         sequence = create_sequence_from_record(repo, otu, record, segment_id)

--- a/ref_builder/otu/isolate.py
+++ b/ref_builder/otu/isolate.py
@@ -180,7 +180,7 @@ def create_isolate(
     )
 
     for segment_id, record in assigned.items():
-        try:
+        if (sequence := otu.get_sequence_by_accession(record.accession)) is None:
             sequence = repo.create_sequence(
                 otu.id,
                 accession=record.accession_version,
@@ -189,8 +189,6 @@ def create_isolate(
                 segment=segment_id,
                 sequence=record.sequence,
             )
-        except ValueError as e:
-            raise e
 
         repo.link_sequence(otu.id, isolate.id, sequence.id)
 

--- a/ref_builder/otu/isolate.py
+++ b/ref_builder/otu/isolate.py
@@ -180,10 +180,17 @@ def create_isolate(
     )
 
     for segment_id, record in assigned.items():
-        sequence = create_sequence_from_record(repo, otu, record, segment_id)
-
-        if sequence is None:
-            raise ValueError("Sequence could not be created.")
+        try:
+            sequence = repo.create_sequence(
+                otu.id,
+                accession=record.accession_version,
+                definition=record.definition,
+                legacy_id=None,
+                segment=segment_id,
+                sequence=record.sequence,
+            )
+        except ValueError as e:
+            raise e
 
         repo.link_sequence(otu.id, isolate.id, sequence.id)
 

--- a/ref_builder/otu/models.py
+++ b/ref_builder/otu/models.py
@@ -14,7 +14,7 @@ from pydantic import (
 from pydantic_core import PydanticCustomError
 
 from ref_builder.models import Molecule
-from ref_builder.plan import Plan
+from ref_builder.plan import Plan, PlanWarning
 from ref_builder.resources import RepoIsolate, RepoSequence
 from ref_builder.utils import Accession, IsolateName, is_accession_key_valid, is_refseq
 
@@ -289,6 +289,14 @@ class OTU(OTUBase):
             return v
 
         return [Isolate.model_validate(isolate.model_dump()) for isolate in v]
+
+    @field_validator("plan", mode="after")
+    def check_plan_required(cls, value: Plan) -> Plan:
+        """Issue a warning if the plan has no required segments."""
+        if not value.required_segments:
+            warnings.warn("Plan has no required segments.", PlanWarning, stacklevel=2)
+
+        return value
 
     @model_validator(mode="after")
     def check_excluded_accessions(self) -> "OTU":

--- a/ref_builder/otu/models.py
+++ b/ref_builder/otu/models.py
@@ -15,7 +15,7 @@ from pydantic_core import PydanticCustomError
 from ref_builder.models import Molecule
 from ref_builder.plan import Plan
 from ref_builder.resources import RepoIsolate, RepoSequence
-from ref_builder.utils import Accession, IsolateName, is_refseq
+from ref_builder.utils import Accession, IsolateName, is_accession_key_valid, is_refseq
 
 
 class SequenceBase(BaseModel):
@@ -70,6 +70,15 @@ class SequenceBase(BaseModel):
 
 class Sequence(SequenceBase):
     """A class representing a sequence with full validation."""
+
+    @field_validator("accession", mode="after")
+    @classmethod
+    def check_accession_key_is_valid(cls, v: Accession) -> Accession:
+        """Check the accession key against INSDC and NCBI RefSeq patterns."""
+        if is_accession_key_valid(v.key):
+            return v
+
+        raise ValueError(f"Accession {v} does not match a valid accession pattern.")
 
 
 class IsolateBase(BaseModel):

--- a/ref_builder/otu/models.py
+++ b/ref_builder/otu/models.py
@@ -174,12 +174,6 @@ class OTUBase(BaseModel):
     acronym: str
     """The OTU acronym (eg. TMV for Tobacco mosaic virus)."""
 
-    excluded_accessions: set[str]
-    """A set of accessions that should not be retrieved in future fetch operations."""
-
-    isolates: list[IsolateBase]
-    """Isolates contained in this OTU."""
-
     legacy_id: str | None
     """A string based ID carried over from a legacy Virtool reference repository."""
 
@@ -192,11 +186,17 @@ class OTUBase(BaseModel):
     plan: Plan
     """The plan for the OTU."""
 
-    representative_isolate: UUID4 | None
-    """The UUID of the representative isolate of this OTU"""
-
     taxid: int
     """The NCBI Taxonomy id for this OTU."""
+
+    excluded_accessions: set[str]
+    """A set of accessions that should not be retrieved in future fetch operations."""
+
+    isolates: list[IsolateBase]
+    """Isolates contained in this OTU."""
+
+    representative_isolate: UUID4 | None
+    """The UUID of the representative isolate of this OTU"""
 
     @property
     def sequences(self) -> list[SequenceBase]:

--- a/ref_builder/otu/models.py
+++ b/ref_builder/otu/models.py
@@ -182,7 +182,9 @@ class Isolate(IsolateBase):
         return [Sequence.model_validate(sequence.model_dump()) for sequence in v]
 
     @field_validator("sequences", mode="after")
-    def check_accession_refseq_or_insdc(cls, v: list[RepoSequence]) -> list[RepoSequence]:
+    def check_accession_refseq_or_insdc(
+        cls, v: list[RepoSequence]
+    ) -> list[RepoSequence]:
         """Check if all sequence accessions are all from RefSeq or all from INSDC.
         If not, warn the user.
         """

--- a/ref_builder/otu/models.py
+++ b/ref_builder/otu/models.py
@@ -184,24 +184,15 @@ class Isolate(IsolateBase):
     @field_validator("sequences", mode="after")
     def check_accession_refseq_or_insdc(cls, v: list[RepoSequence]) -> list[RepoSequence]:
         """Check if all sequence accessions are all from RefSeq or all from INSDC.
-
         If not, warn the user.
         """
-        isolate_accessions = {sequence.accession for sequence in v}
-
-        if any(is_refseq(accession.key) for accession in isolate_accessions):
-            if all(is_refseq(accession.key) for accession in isolate_accessions):
-                return v
-
-        elif all(not is_refseq(accession.key) for accession in isolate_accessions):
-            return v
-
-        warnings.warn(
-            "Combination of RefSeq and non-RefSeq sequences found in multipartite isolate: "
-            + f"{[sequence.accession.key for sequence in v]}",
-            IsolateInconsistencyWarning,
-            stacklevel=1,
-        )
+        if len({s.refseq for s in v}) > 1:
+            warnings.warn(
+                "Combination of RefSeq and non-RefSeq sequences found in multipartite isolate: "
+                + f"{[sequence.accession.key for sequence in v]}",
+                IsolateInconsistencyWarning,
+                stacklevel=1,
+            )
 
         return v
 

--- a/ref_builder/otu/update.py
+++ b/ref_builder/otu/update.py
@@ -510,13 +510,13 @@ def update_otu_with_records(
         for isolate_name, isolate_records in group_genbank_records_by_isolate(
             divided_records
         ).items():
-            with repo.use_transaction():
+            with repo.use_transaction() as transaction:
                 isolate = create_isolate(
                     repo, otu, isolate_name, list(isolate_records.values())
                 )
 
                 if isolate is None:
-                    raise AbortTransactionError()
+                    raise transaction.abort()
 
             if isolate:
                 new_isolate_ids.append(isolate.id)

--- a/ref_builder/otu/update.py
+++ b/ref_builder/otu/update.py
@@ -515,7 +515,10 @@ def update_otu_with_records(
                         repo, otu, isolate_name, list(isolate_records.values())
                     )
                 except ValueError as e:
-                    logger.error("Error encountered while creating sequence.", error_message=str(e))
+                    logger.error(
+                        "Error encountered while creating sequence.",
+                        error_message=str(e),
+                    )
 
                     isolate = None
 

--- a/ref_builder/otu/update.py
+++ b/ref_builder/otu/update.py
@@ -25,7 +25,6 @@ from ref_builder.otu.utils import (
 from ref_builder.repo import Repo
 from ref_builder.resources import RepoIsolate, RepoOTU
 from ref_builder.utils import IsolateName
-from ref_builder.transaction import AbortTransactionError
 
 logger = get_logger("otu.update")
 
@@ -511,9 +510,14 @@ def update_otu_with_records(
             divided_records
         ).items():
             with repo.use_transaction() as transaction:
-                isolate = create_isolate(
-                    repo, otu, isolate_name, list(isolate_records.values())
-                )
+                try:
+                    isolate = create_isolate(
+                        repo, otu, isolate_name, list(isolate_records.values())
+                    )
+                except ValueError as e:
+                    logger.error("Error encountered while creating sequence.", error_message=str(e))
+
+                    isolate = None
 
                 if isolate is None:
                     raise transaction.abort()

--- a/ref_builder/otu/utils.py
+++ b/ref_builder/otu/utils.py
@@ -272,6 +272,12 @@ def assign_records_to_segments(
     :param plan: A plan.
     :return: A dictionary of segment IDs as keys and records as values.
     """
+    if len(records) < len(plan.required_segments):
+        raise PlanConformationError(
+            "There are not enough records to fulfill all needed segments: "
+            f"{len(records)} < {len(plan.required_segments)}"
+        )
+
     seen_segment_names = Counter(
         extract_segment_name_from_record_with_plan(record, plan) for record in records
     )

--- a/ref_builder/otu/validate.py
+++ b/ref_builder/otu/validate.py
@@ -61,11 +61,15 @@ def check_otu_is_valid(unvalidated_otu: RepoOTU) -> bool:
     return True
 
 
-def otu_error_handler(e: ValidationError):
+def otu_error_handler(e: ValidationError) -> list[dict[str, Any]]:
+    """Add contextual metadata to OTU validation errors."""
     new_errors: list[dict[str, Any]] = e.errors()
 
     for error in new_errors:
         if not error["loc"]:
+            if error["type"] == "segment_not_found":
+                error["loc"] = (f"isolates[{error['ctx'].get('isolate_id')}]",)
+
             if error["type"] in ("sequence_too_short", "sequence_too_long"):
                 error["loc"] = (
                     (
@@ -73,5 +77,6 @@ def otu_error_handler(e: ValidationError):
                         f"sequences[{error['ctx'].get('sequence_id', '')}]",
                     ),
                 )
+
 
     return new_errors

--- a/ref_builder/otu/validate.py
+++ b/ref_builder/otu/validate.py
@@ -41,7 +41,8 @@ def check_otu_is_valid(unvalidated_otu: RepoOTU) -> bool:
 
         for error in otu_errors:
             logger.warning(
-                "ValidationError: " + error["msg"],
+                "ValidationError",
+                msg=error["msg"],
                 type=error["type"],
                 loc=error["loc"],
                 input=error["input"] if not isinstance(error["input"], dict) else {},
@@ -77,6 +78,5 @@ def otu_error_handler(e: ValidationError) -> list[dict[str, Any]]:
                         f"sequences[{error['ctx'].get('sequence_id', '')}]",
                     ),
                 )
-
 
     return new_errors

--- a/ref_builder/repo.py
+++ b/ref_builder/repo.py
@@ -457,17 +457,8 @@ class Repo:
             extant_sequence = otu.get_sequence_by_accession(versioned_accession.key)
 
             if extant_sequence is not None:
-                if extant_sequence.accession == versioned_accession:
-                    logger.warning(
-                        "This accession already exists in the OTU.",
-                        accession=str(extant_sequence.accession),
-                        otu_id=str(otu_id),
-                    )
-                    return None
-
-                logger.warning(
-                    "New version of accession found.",
-                    accession=versioned_accession.key,
+                raise ValueError(
+                    f"Accession {versioned_accession} already exists in the OTU.",
                 )
 
         sequence_id = uuid.uuid4()

--- a/ref_builder/repo.py
+++ b/ref_builder/repo.py
@@ -398,9 +398,6 @@ class Repo:
         """
         otu = self.get_otu(otu_id)
 
-        if name is not None and otu.get_isolate_id_by_name(name):
-            raise ValueError(f"Isolate name already exists: {name}")
-
         isolate_id = uuid.uuid4()
 
         event = self._write_event(

--- a/ref_builder/resources.py
+++ b/ref_builder/resources.py
@@ -1,11 +1,10 @@
 import datetime
-import warnings
 from uuid import UUID
 
 from pydantic import UUID4, BaseModel, Field, field_serializer, field_validator
 
 from ref_builder.models import Molecule
-from ref_builder.plan import Plan, PlanWarning
+from ref_builder.plan import Plan
 from ref_builder.utils import Accession, DataType, IsolateName
 
 
@@ -351,11 +350,3 @@ class RepoOTU(BaseModel):
     def unlink_sequence(self, isolate_id: UUID4, sequence_id: UUID4) -> None:
         """Unlink the given sequence from the given isolate. Used only during rehydration."""
         self.get_isolate(isolate_id).delete_sequence(sequence_id)
-
-    @field_validator("plan", mode="after")
-    def check_plan_required(cls, value: Plan):
-        """Issue a warning if the plan has no required segments."""
-        if not value.required_segments:
-            warnings.warn("Plan has no required segments.", PlanWarning, stacklevel=1)
-
-        return value

--- a/ref_builder/utils.py
+++ b/ref_builder/utils.py
@@ -140,11 +140,19 @@ def format_json(path: Path) -> None:
         f.write(orjson.dumps(data, option=orjson.OPT_INDENT_2))
 
 
+def is_accession_key_valid(accession_key: str) -> bool:
+    """Return True if the given accession is a valid Genbank or RefSeq accession."""
+    return (
+        GENBANK_ACCESSION_PATTERN.match(accession_key) is not None
+        or REFSEQ_ACCESSION_PATTERN.match(accession_key) is not None
+    )
+
+
 def get_accession_key(raw: str) -> str:
     """Parse a string to check if it follows Genbank or RefSeq accession parameters and
     return the key part only.
     """
-    if GENBANK_ACCESSION_PATTERN.match(raw) or REFSEQ_ACCESSION_PATTERN.match(raw):
+    if is_accession_key_valid(raw):
         return raw
 
     try:

--- a/tests/test_promote.py
+++ b/tests/test_promote.py
@@ -1,3 +1,5 @@
+import pytest
+
 from ref_builder.ncbi.client import NCBIClient
 from ref_builder.otu.create import create_otu_with_taxid
 from ref_builder.otu.promote import (
@@ -52,6 +54,7 @@ def test_replace_sequence(empty_repo):
     }
 
 
+@pytest.mark.filterwarnings()
 def test_multi_linked_promotion(empty_repo: Repo):
     """Test the promotion of a sequence that is linked to more than one isolate."""
     with empty_repo.lock():

--- a/tests/test_resources.py
+++ b/tests/test_resources.py
@@ -58,39 +58,6 @@ class TestIsolate:
 class TestOTU:
     """Test properties of RepoOTU."""
 
-    def test_no_required_segments(self):
-        """Test that RepoOTU raises a warning if initialized without required segments."""
-        with pytest.warns(PlanWarning):
-            otu = RepoOTU(
-                id=uuid4(),
-                acronym="TMV",
-                excluded_accessions=set(),
-                isolates=[],
-                legacy_id=None,
-                molecule=Molecule(
-                    strandedness=Strandedness.SINGLE,
-                    type=MolType.RNA,
-                    topology=Topology.LINEAR,
-                ),
-                name="Tobacco mosaic virus",
-                representative_isolate=None,
-                plan=Plan(
-                    id=uuid4(),
-                    segments=[
-                        Segment(
-                            id=uuid4(),
-                            length=6395,
-                            length_tolerance=0.03,
-                            name=None,
-                            rule=SegmentRule.RECOMMENDED,
-                        )
-                    ],
-                ),
-                taxid=12242,
-            )
-
-        assert not otu.plan.required_segments
-
     def test_no_isolates(self):
         """Test that an isolate initializes correctly with no isolates."""
         otu = RepoOTU(


### PR DESCRIPTION
Offload some function-dependent validation onto the `OTU` validator model for more consistent results across different functions. 

Resolves GH-147 and GH-149.

* add `Sequence.check_accession_key_is_valid()` field validator
* add `Isolate.check_accession_consistency()` field validator
* add `OTU.check_isolates_against_plan()` model validator
* add `OTU.check_plan_required()` field validator (removed from `RepoOTU`)
* add `PlanConformationError`
* add `IsolateInconsistencyWarning`
* add `otu.validators.otu_error_handler()`