### PR TITLE
add `ref-builder otu upgrade IDENTIFIER`

### DIFF
--- a/ref_builder/ncbi/cache.py
+++ b/ref_builder/ncbi/cache.py
@@ -47,7 +47,7 @@ class NCBICache:
 
         Returns ``None`` if the record is not found in the cache.
 
-        :param accession: The NCBI accession of the record
+        :param accession: The primary NCBI accession of the record, sans version.
         :param version: The accession's version number. Defaults to wildcard.
         :return: Deserialized Genbank data if file is found in cache, else None
         """

--- a/ref_builder/otu/builders/isolate.py
+++ b/ref_builder/otu/builders/isolate.py
@@ -4,7 +4,7 @@ from pydantic import field_serializer, field_validator
 
 from ref_builder.otu.builders.sequence import SequenceBuilder
 from ref_builder.otu.models import IsolateModel
-from ref_builder.utils import IsolateName
+from ref_builder.utils import Accession, IsolateName
 
 
 class IsolateBuilder(IsolateModel):
@@ -17,6 +17,11 @@ class IsolateBuilder(IsolateModel):
     def accessions(self) -> set[str]:
         """A set of accession numbers for sequences in the isolate."""
         return {sequence.accession.key for sequence in self.sequences}
+
+    @property
+    def versioned_accessions(self) -> set[Accession]:
+        """A set of versioned accessions contained in this isolate."""
+        return {sequence.accession for sequence in self.sequences}
 
     @property
     def sequence_ids(self) -> set[UUID]:

--- a/ref_builder/otu/builders/otu.py
+++ b/ref_builder/otu/builders/otu.py
@@ -5,7 +5,7 @@ from pydantic import UUID4
 from ref_builder.otu.builders.isolate import IsolateBuilder
 from ref_builder.otu.builders.sequence import SequenceBuilder
 from ref_builder.otu.models import OTUModel
-from ref_builder.utils import IsolateName
+from ref_builder.utils import Accession, IsolateName
 
 
 class OTUBuilder(OTUModel):
@@ -37,6 +37,11 @@ class OTUBuilder(OTUModel):
     def accessions(self) -> set[str]:
         """A set of accessions contained in this isolate."""
         return {sequence.accession.key for sequence in self._sequences_by_id.values()}
+
+    @property
+    def versioned_accessions(self) -> set[Accession]:
+        """A set of versioned accessions contained in this OTU."""
+        return {sequence.accession for sequence in self._sequences_by_id.values()}
 
     @property
     def blocked_accessions(self) -> set[str]:

--- a/ref_builder/repo.py
+++ b/ref_builder/repo.py
@@ -453,7 +453,7 @@ class Repo:
         if versioned_accession.key in otu.accessions:
             extant_sequence = otu.get_sequence_by_accession(versioned_accession.key)
 
-            if extant_sequence is not None:
+            if extant_sequence.accession == versioned_accession:
                 raise ValueError(
                     f"Accession {versioned_accession} already exists in the OTU.",
                 )

--- a/ref_builder/repo.py
+++ b/ref_builder/repo.py
@@ -453,13 +453,10 @@ class Repo:
         else:
             versioned_accession = Accession.from_string(accession)
 
-        if versioned_accession.key in otu.accessions:
-            extant_sequence = otu.get_sequence_by_accession(versioned_accession.key)
-
-            if extant_sequence.accession == versioned_accession:
-                raise ValueError(
-                    f"Accession {versioned_accession} already exists in the OTU.",
-                )
+        if versioned_accession in otu.versioned_accessions:
+            raise ValueError(
+                f"Accession {versioned_accession} already exists in the OTU.",
+            )
 
         sequence_id = uuid.uuid4()
 

--- a/ref_builder/repo.py
+++ b/ref_builder/repo.py
@@ -437,7 +437,7 @@ class Repo:
     def create_sequence(
         self,
         otu_id: uuid.UUID,
-        accession: str,
+        accession: str | Accession,
         definition: str,
         legacy_id: str | None,
         segment: uuid.UUID,
@@ -448,7 +448,10 @@ class Repo:
         """
         otu = self.get_otu(otu_id)
 
-        versioned_accession = Accession.from_string(accession)
+        if isinstance(accession, Accession):
+            versioned_accession = accession
+        else:
+            versioned_accession = Accession.from_string(accession)
 
         if versioned_accession.key in otu.accessions:
             extant_sequence = otu.get_sequence_by_accession(versioned_accession.key)

--- a/tests/test_promote.py
+++ b/tests/test_promote.py
@@ -1,4 +1,8 @@
+import datetime
+
+import arrow
 import pytest
+from structlog.testing import capture_logs
 
 from ref_builder.ncbi.client import NCBIClient
 from ref_builder.otu.builders.isolate import IsolateBuilder
@@ -6,8 +10,10 @@ from ref_builder.otu.create import create_otu_with_taxid
 from ref_builder.otu.promote import (
     promote_otu_accessions_from_records,
     replace_otu_sequence_from_record,
+    upgrade_outdated_sequences_in_otu,
 )
 from ref_builder.repo import Repo
+from ref_builder.utils import Accession
 from tests.fixtures.factories import IsolateFactory
 
 
@@ -151,3 +157,84 @@ def test_multi_linked_promotion(empty_repo: Repo):
     assert otu_after_promote.get_isolate(isolate_init.id).accessions == (
         {"NC_055390", "FA000001", "FA000002"}
     )
+
+
+@pytest.mark.ncbi()
+class TestUpgradeSequencesInOTU:
+    """Test OTU-wide outdated sequence version upgrade."""
+
+    def test_ok(self, precached_repo: Repo):
+        """Test a simple fetch and replace upgrade."""
+        with precached_repo.lock():
+            otu_init = create_otu_with_taxid(
+                precached_repo,
+                196375,
+                ["NC_004452.1"],
+                acronym="",
+            )
+
+        assert "NC_004452" in otu_init.accessions
+
+        outdated_sequence = otu_init.get_sequence_by_accession("NC_004452")
+
+        containing_isolate_id = list(
+            otu_init.get_isolate_ids_containing_sequence_id(outdated_sequence.id)
+        )[0]
+
+        containing_isolate_init = otu_init.get_isolate(containing_isolate_id)
+
+        assert outdated_sequence.accession.version == 1
+
+        with precached_repo.lock():
+            upgraded_sequence_ids = upgrade_outdated_sequences_in_otu(
+                precached_repo, otu_init
+            )
+
+        updated_sequence_id = list(upgraded_sequence_ids)[0]
+
+        otu_after = precached_repo.get_otu(otu_init.id)
+
+        assert containing_isolate_init.id in otu_after.isolate_ids
+
+        containing_isolate_after = otu_after.get_isolate(containing_isolate_id)
+
+        assert (
+            containing_isolate_after.sequence_ids
+            != containing_isolate_init.sequence_ids
+        )
+
+        assert containing_isolate_after.sequence_ids == {updated_sequence_id}
+
+        updated_sequence = otu_after.get_sequence_by_id(updated_sequence_id)
+
+        assert updated_sequence.accession.key == outdated_sequence.accession.key
+
+        assert updated_sequence.accession.version > outdated_sequence.accession.version
+
+    def test_with_future_date_limit(self, precached_repo: Repo):
+        """Test that setting modification_date_start to a future date does returns no new sequences."""
+        with precached_repo.lock():
+            otu_init = create_otu_with_taxid(
+                precached_repo,
+                196375,
+                ["NC_004452.1"],
+                acronym="",
+            )
+
+        assert "NC_004452" in otu_init.accessions
+
+        assert otu_init.get_sequence_by_accession("NC_004452").accession == (
+            Accession(key="NC_004452", version=1)
+        )
+
+        with precached_repo.lock(), capture_logs() as captured_logs:
+            upgrade_outdated_sequences_in_otu(
+                precached_repo,
+                otu_init,
+                modification_date_start=arrow.utcnow().naive
+                + datetime.timedelta(days=1),
+            )
+
+        assert any(
+            log.get("event") == "All sequences are up to date." for log in captured_logs
+        )


### PR DESCRIPTION
Add a new OTU command to upgrade sequences that have undergone modification in NCBI Nucleotide since last added.

Resolves GH-148.

* add `OTUBuilder.versioned_accessions` property
* refactor `Repo.create_sequence()`, `otu.promote.replace_otu_sequence_from_record()` to use `OTU.versioned_accessions` to check for sequence clash
* refactor `NCBIClient.fetch_genbank_records()` to take accession version into account when retrieving from cache
* add `otu.promote_otu_accessions_from_records()`
* add `test_promote::TestUpgradeSequencesInOTU`, `test_otu_commands::TestUpgradeOTUCommand`