### PR TITLE
refactor `Index` methods using type adapters and converters

### DIFF
--- a/ref_builder/index.py
+++ b/ref_builder/index.py
@@ -165,7 +165,9 @@ class Index:
     @property
     def otu_ids(self) -> set[UUID]:
         """A list of all OTUs tracked in the index."""
-        return {row[0] for row in self.con.execute('SELECT id AS "id [uuid]" FROM otus')}
+        return {
+            row[0] for row in self.con.execute('SELECT id AS "id [uuid]" FROM otus')
+        }
 
     def add_event_id(
         self,
@@ -379,7 +381,10 @@ class Index:
     def iter_minimal_otus(self) -> Iterator[OTUMinimal]:
         """Iterate over minimal representations of all OTUs in the index."""
         rows = self.con.execute(
-            'SELECT acronym, id AS "id [uuid]", legacy_id, name, taxid FROM otus ORDER BY name',
+            """
+            SELECT acronym, id AS "id [uuid]", legacy_id, name, taxid
+            FROM otus ORDER BY name
+            """,
         ).fetchall()
 
         for row in rows:
@@ -395,7 +400,7 @@ class Index:
         """Get the timestamp of the last event in an update for an OTU."""
         cursor = self.con.execute(
             """
-            SELECT timestamp_complete FROM otu_updates 
+            SELECT timestamp_complete FROM otu_updates
             WHERE otu_id = ? ORDER BY id DESC
             """,
             (otu_id,),
@@ -449,9 +454,7 @@ class Index:
         otu = OTUBuilder.model_validate_json(otu_json)
 
         sequence_ids = [
-            sequence.id
-            for isolate in otu.isolates
-            for sequence in isolate.sequences
+            sequence.id for isolate in otu.isolates for sequence in isolate.sequences
         ]
 
         # Fetch all sequences in a single query
@@ -493,9 +496,7 @@ class Index:
 
         Only sequences that have changed will be updated.
         """
-        sequence_ids = {
-            seq.id for isolate in otu.isolates for seq in isolate.sequences
-        }
+        sequence_ids = {seq.id for isolate in otu.isolates for seq in isolate.sequences}
 
         placeholders = ",".join("?" for _ in sequence_ids)
 
@@ -553,7 +554,7 @@ class Index:
         self.con.execute(
             """
             INSERT OR REPLACE INTO otus (id, acronym, at_event, legacy_id, name, otu, taxid)
-            VALUES (?, ?,?, ?, ?, ?, ?)
+            VALUES (?, ?, ?, ?, ?, ?, ?)
             """,
             (
                 otu.id,

--- a/ref_builder/index.py
+++ b/ref_builder/index.py
@@ -66,7 +66,12 @@ class Index:
 
         self.path.parent.mkdir(exist_ok=True, parents=True)
 
-        self.con = sqlite3.connect(path, isolation_level=None)
+        self.con = sqlite3.connect(
+            path,
+            isolation_level=None,
+            detect_types=sqlite3.PARSE_DECLTYPES | sqlite3.PARSE_COLNAMES,
+        )
+
         self.con.execute("PRAGMA journal_mode = WAL")
         self.con.execute("PRAGMA synchronous = NORMAL")
 

--- a/ref_builder/index.py
+++ b/ref_builder/index.py
@@ -576,17 +576,3 @@ def _calculate_crc32(sequence: str) -> str:
 
     # Convert CRC as a hexadecimal string.
     return hex(crc & 0xFFFFFFFF)[2:].zfill(8)
-
-
-def _default_json(obj: Any) -> list:
-    """Cast sets to lists.
-
-    This function is used as the default argument to `orjson.dumps` to handle sets.
-
-    :param obj: the object to serialize
-    :return: the serialized object
-    """
-    if isinstance(obj, set):
-        return list(obj)
-
-    raise TypeError(f"Object of type {obj.__class__.__name__} is not JSON serializable")

--- a/ref_builder/index.py
+++ b/ref_builder/index.py
@@ -51,10 +51,16 @@ def convert_uuid(string_uuid: bytes) -> UUID:
     return UUID(string_uuid.decode())
 
 
+def convert_datetime(string_datetime: bytes) -> datetime.datetime:
+    """Automatically convert stringified datetime back to datetime type."""
+    return datetime.datetime.fromisoformat(string_datetime.decode())
+
+
 sqlite3.register_adapter(UUID, adapt_uuid)
 sqlite3.register_adapter(datetime.datetime, adapt_datetime)
 
 sqlite3.register_converter("uuid", convert_uuid)
+sqlite3.register_converter("datetime", convert_datetime)
 
 
 class Index:
@@ -214,6 +220,7 @@ class Index:
         cursor = self.con.execute(
             """
             SELECT timestamp
+            AS "timestamp [datetime]"
             FROM events
             WHERE otu_id = ?
             ORDER BY event_id
@@ -222,7 +229,7 @@ class Index:
         )
 
         if result := cursor.fetchone():
-            return datetime.datetime.fromisoformat(result[0])
+            return result[0]
 
         return None
 
@@ -231,6 +238,7 @@ class Index:
         cursor = self.con.execute(
             """
             SELECT timestamp
+            AS "timestamp [datetime]"
             FROM events
             WHERE otu_id = ?
             ORDER BY event_id DESC
@@ -239,7 +247,7 @@ class Index:
         )
 
         if result := cursor.fetchone():
-            return datetime.datetime.fromisoformat(result[0])
+            return result[0]
 
         return None
 
@@ -410,7 +418,7 @@ class Index:
             """,
             (
                 otu_id,
-                timestamp.isoformat(),
+                timestamp,
             ),
         )
 

--- a/ref_builder/index.py
+++ b/ref_builder/index.py
@@ -464,8 +464,6 @@ class Index:
             str(seq.id) for isolate in otu.isolates for seq in isolate.sequences
         }
 
-        otu_dict = otu.model_dump(mode="json")
-
         placeholders = ",".join("?" for _ in sequence_ids)
 
         # Delete any sequences that are no longer in the OTU.
@@ -479,24 +477,24 @@ class Index:
         batch = []
 
         # Insert or update the isolates.
-        for isolate in otu_dict["isolates"]:
+        for isolate in otu.isolates:
             self.con.execute(
                 "INSERT OR REPLACE INTO isolates (id, name, otu_id) VALUES (?, ?, ?)",
                 (
-                    str(isolate["id"]),
-                    str(isolate["name"]),
-                    str(otu_dict["id"]),
+                    str(isolate.id),
+                    str(isolate.name),
+                    str(otu.id),
                 ),
             )
 
-            for sequence in isolate["sequences"]:
-                crc = _calculate_crc32(sequence["sequence"])
+            for sequence in isolate.sequences:
+                crc = _calculate_crc32(sequence.sequence)
                 batch.append(
                     (
-                        str(sequence["id"]),
+                        str(sequence.id),
                         crc,
                         str(otu.id),
-                        sequence["sequence"],
+                        sequence.sequence,
                     ),
                 )
 
@@ -530,7 +528,7 @@ class Index:
                 at_event,
                 otu.legacy_id,
                 otu.name,
-                orjson.dumps(otu_dict),
+                otu.model_dump_json(),
                 otu.taxid,
             ),
         )


### PR DESCRIPTION
Utilize [adapters](https://docs.python.org/3/library/sqlite3.html#how-to-adapt-custom-python-types-to-sqlite-values) and [converters](https://docs.python.org/3/library/sqlite3.html#how-to-convert-sqlite-values-to-custom-python-types) to cut down on inline type casting and conversion when dealing with SQLite data.

* add `index.adapt_uuid()`/`.convert_uuid()`, `.adapt_datetime()`/ `.convert_uuid()`