### PR TITLE
improvements to `NCBIClient.fetch_taxonomy()`, etc.

### DIFF
--- a/ref_builder/ncbi/client.py
+++ b/ref_builder/ncbi/client.py
@@ -3,7 +3,7 @@
 import datetime
 import os
 from collections.abc import Collection
-from contextlib import contextmanager
+from contextlib import contextmanager, suppress
 from enum import StrEnum
 from http import HTTPStatus
 from urllib.error import HTTPError
@@ -452,10 +452,8 @@ class NCBIClient:
         """Filter raw eSearch accession list and return a set of compliant Nucleotide accessions."""
         valid_accessions = set()
         for accession in raw_accessions:
-            try:
+            with suppress(ValueError):
                 valid_accessions.add(Accession.from_string(accession))
-            except ValueError:
-                pass
 
         return valid_accessions
 

--- a/ref_builder/ncbi/client.py
+++ b/ref_builder/ncbi/client.py
@@ -19,7 +19,6 @@ from ref_builder.ncbi.models import (
     NCBIGenbank,
     NCBIRank,
     NCBITaxonomy,
-    TaxonLevelError,
 )
 from ref_builder.utils import Accession
 
@@ -36,6 +35,10 @@ ESEARCH_PAGE_SIZE = 1000
 
 DATE_TEMPLATE = "%Y/%m/%d"
 """The standard date format used by NCBI Entrez."""
+
+
+class TaxonLevelError(ValueError):
+    """Raised when a fetched taxonomy record is above species level."""
 
 
 class GenbankRecordKey(StrEnum):
@@ -330,9 +333,6 @@ class NCBIClient:
         try:
             return NCBITaxonomy.model_validate(record)
 
-        except TaxonLevelError:
-            raise ValueError(f"Requested Taxonomy {taxid} is too high a level.")
-
         except ValidationError as e:
             for error in e.errors():
                 logger.warning(
@@ -341,6 +341,9 @@ class NCBIClient:
                     location=error["loc"],
                     type=error["type"],
                 )
+
+                if error["type"] == "taxon_rank_too_high":
+                    raise TaxonLevelError(error["msg"])
 
         return None
 

--- a/ref_builder/ncbi/client.py
+++ b/ref_builder/ncbi/client.py
@@ -102,8 +102,9 @@ class NCBIClient:
 
             if records:
                 logger.debug(
-                    f"Loaded {len(records)} cached records",
-                    cached_accessions=[
+                    "Loaded cached records",
+                    record_count=len(records),
+                    cached_records=[
                         record.get(GenbankRecordKey.PRIMARY_ACCESSION)
                         for record in records
                     ],
@@ -170,7 +171,7 @@ class NCBIClient:
             if e.code == HTTPStatus.BAD_REQUEST:
                 logger.exception("Accessions not found")
             else:
-                logger.exception()
+                logger.exception("HTTPError")
 
             return []
 
@@ -338,7 +339,7 @@ class NCBIClient:
                 logger.warning(
                     "ValidationError",
                     msg=error["msg"],
-                    location=error["loc"],
+                    loc=error["loc"],
                     type=error["type"],
                 )
 
@@ -400,7 +401,7 @@ class NCBIClient:
         logger = base_logger.bind(name=name)
         try:
             with log_http_error():
-                handle = Entrez.esearch(db="taxonomy", term=name)
+                handle = Entrez.esearch(db=NCBIDatabase.TAXONOMY, term=name)
         except HTTPError:
             return None
 
@@ -508,10 +509,12 @@ class NCBIClient:
             if end_date:
                 end_date_string = end_date.strftime(DATE_TEMPLATE)
 
-        return (
-            f'"{start_date_string}"[{filter_type}]'
-            + " : "
-            + f'"{end_date_string}"[{filter_type}]'
+        return " ".join(
+            [
+                f'"{start_date_string}"[{filter_type}]',
+                ":",
+                f'"{end_date_string}"[{filter_type}]',
+            ]
         )
 
 

--- a/ref_builder/ncbi/models.py
+++ b/ref_builder/ncbi/models.py
@@ -26,6 +26,9 @@ class NCBIDatabase(StrEnum):
 class NCBIRank(StrEnum):
     """NCBI ranks used in ref-builder."""
 
+    FAMILY = "family"
+    ORDER = "order"
+    GENUS = "genus"
     SPECIES = "species"
     ISOLATE = "isolate"
     NO_RANK = "no rank"

--- a/tests/ncbi/test_client.py
+++ b/tests/ncbi/test_client.py
@@ -249,6 +249,18 @@ class TestFetchTaxonomy:
         """Test that the client returns None when the taxid does not exist."""
         assert uncached_ncbi_client.fetch_taxonomy_record(99999999) is None
 
+    def test_rank_too_high(
+        self,
+        uncached_ncbi_client: NCBIClient,
+        snapshot: SnapshotAssertion,
+    ):
+        """Test behaviour when the requested taxonomy rank is above species level."""
+        taxon_record = uncached_ncbi_client.fetch_taxonomy_record(190729)
+
+        assert taxon_record
+
+        print(taxon_record.model_dump())
+
 
 @pytest.mark.ncbi()
 def test_fetch_spelling():

--- a/tests/ncbi/test_client.py
+++ b/tests/ncbi/test_client.py
@@ -239,17 +239,15 @@ class TestFetchTaxonomy:
         # Make sure the taxid is now cached.
         assert uncached_ncbi_client.cache.load_taxonomy(1198450)
 
+    def test_fetch_taxonomy_by_name(self):
+        """Test that the client can fetch a taxid by name."""
+        assert (
+            NCBIClient.fetch_taxonomy_id_by_name("Rhynchosia golden mosaic virus") == 117198
+        )
+
     def test_not_found(self, uncached_ncbi_client: NCBIClient):
         """Test that the client returns None when the taxid does not exist."""
         assert uncached_ncbi_client.fetch_taxonomy_record(99999999) is None
-
-
-@pytest.mark.ncbi()
-def test_fetch_taxonomy_by_name():
-    """Test that the client can fetch a taxid by name."""
-    assert (
-        NCBIClient.fetch_taxonomy_id_by_name("Rhynchosia golden mosaic virus") == 117198
-    )
 
 
 @pytest.mark.ncbi()

--- a/tests/ncbi/test_client.py
+++ b/tests/ncbi/test_client.py
@@ -3,7 +3,7 @@ import datetime
 import pytest
 from syrupy import SnapshotAssertion
 
-from ref_builder.ncbi.client import NCBIClient
+from ref_builder.ncbi.client import NCBIClient, TaxonLevelError
 from ref_builder.utils import Accession
 
 
@@ -249,17 +249,15 @@ class TestFetchTaxonomy:
         """Test that the client returns None when the taxid does not exist."""
         assert uncached_ncbi_client.fetch_taxonomy_record(99999999) is None
 
-    def test_rank_too_high(
+    def test_rank_too_high_fail(
         self,
         uncached_ncbi_client: NCBIClient,
-        snapshot: SnapshotAssertion,
     ):
-        """Test behaviour when the requested taxonomy rank is above species level."""
-        taxon_record = uncached_ncbi_client.fetch_taxonomy_record(190729)
-
-        assert taxon_record
-
-        print(taxon_record.model_dump())
+        """Test that if the requested taxonomy rank is above species level,
+        the correct error is raised.
+        """
+        with pytest.raises(TaxonLevelError):
+            uncached_ncbi_client.fetch_taxonomy_record(190729)
 
 
 @pytest.mark.ncbi()

--- a/tests/ncbi/test_client.py
+++ b/tests/ncbi/test_client.py
@@ -242,7 +242,8 @@ class TestFetchTaxonomy:
     def test_fetch_taxonomy_by_name(self):
         """Test that the client can fetch a taxid by name."""
         assert (
-            NCBIClient.fetch_taxonomy_id_by_name("Rhynchosia golden mosaic virus") == 117198
+            NCBIClient.fetch_taxonomy_id_by_name("Rhynchosia golden mosaic virus")
+            == 117198
         )
 
     def test_not_found(self, uncached_ncbi_client: NCBIClient):


### PR DESCRIPTION
Allows `NCBITaxonomy` to handle taxonomical rank issues using internal validator.

* add `client.TaxonLevelError`
* add rank validators to `NCBITaxonomy`
* add some higher-level ranks to `NCBIRank` for convenience
* clean up `NCBIClient.fetch_accessions_by_taxid()`
* add `TestFetchTaxonomy.test_rank_too_high_fail()`