### PR TITLE
add `--no-color` option to top-level command

### DIFF
--- a/ref_builder/cli/main.py
+++ b/ref_builder/cli/main.py
@@ -10,6 +10,10 @@ from rich.table import Table
 from ref_builder.build import build_json
 from ref_builder.cli.event import event
 from ref_builder.cli.isolate import isolate
+from ref_builder.cli.options import (
+    legacy_repo_path_option,
+    path_option,
+)
 from ref_builder.cli.otu import otu
 from ref_builder.console import console
 from ref_builder.legacy.convert import convert_legacy_repo
@@ -17,10 +21,6 @@ from ref_builder.legacy.utils import iter_legacy_otus
 from ref_builder.legacy.validate import validate_legacy_repo
 from ref_builder.logs import configure_logger
 from ref_builder.ncbi.client import NCBIClient
-from ref_builder.cli.options import (
-    legacy_repo_path_option,
-    path_option,
-)
 from ref_builder.repo import Repo
 from ref_builder.utils import DataType, format_json
 
@@ -33,12 +33,13 @@ logger = structlog.get_logger()
 @click.group()
 @click.option("--debug", is_flag=True, help="Show debug logs")
 @click.option("-v", "--verbose", "verbosity", count=True)
-def entry(debug: bool, verbosity: int) -> None:
+@click.option("--no-color", is_flag=True, help="Disable colored output.")
+def entry(debug: bool, verbosity: int, no_color: bool) -> None:
     """Build and maintain reference sets of pathogen genome sequences."""
     if debug:
         verbosity = 2
 
-    configure_logger(verbosity)
+    configure_logger(verbosity, no_color)
 
 
 @entry.command()

--- a/ref_builder/logs.py
+++ b/ref_builder/logs.py
@@ -1,12 +1,16 @@
 import logging
+import os
 
 import structlog
 
+NO_COLOR = os.environ.get("NO_COLOR") is not None
 
-def configure_logger(verbosity: int) -> None:
+
+def configure_logger(verbosity: int, no_color: bool = False) -> None:
     """Configure structlog-based logging.
 
     :param verbosity: The verbosity level of the logger.
+    :param no_color: Disable colored input, even if global settings allow it.
     """
     # Disable faker logging.
     logging.getLogger("faker").setLevel(logging.ERROR)
@@ -31,8 +35,11 @@ def configure_logger(verbosity: int) -> None:
                 ]
             )
         )
+    if no_color or NO_COLOR:
+        processors.append(structlog.processors.JSONRenderer())
 
-    processors.append(structlog.dev.ConsoleRenderer())
+    else:
+        processors.append(structlog.dev.ConsoleRenderer())
 
     structlog.configure(
         logger_factory=structlog.PrintLoggerFactory(),

--- a/tests/cli/test_entry_command.py
+++ b/tests/cli/test_entry_command.py
@@ -1,0 +1,28 @@
+from click.testing import CliRunner
+
+from ref_builder.cli.main import entry
+
+runner = CliRunner()
+
+
+def test_ok():
+    """Test that interface loads up as expected"""
+    result = runner.invoke(entry, ["--help"])
+
+    assert result.exit_code == 0
+
+    assert (
+        "Build and maintain reference sets of pathogen genome sequences."
+        in result.output
+    )
+
+
+def test_no_color_ok():
+    result = runner.invoke(entry, ["--no-color", "--help"])
+
+    assert result.exit_code == 0
+
+    assert (
+        "Build and maintain reference sets of pathogen genome sequences."
+        in result.output
+    )

--- a/tests/cli/test_otu_commands.py
+++ b/tests/cli/test_otu_commands.py
@@ -111,7 +111,7 @@ class TestCreateOTUCommands:
         assert "Duplicate accessions are not allowed." in result.output
 
 
-@pytest.mark.ncbi
+@pytest.mark.ncbi()
 class TestPromoteOTUCommand:
     """Test that the ``ref-builder otu promote`` command works as planned."""
 


### PR DESCRIPTION
Comply with suggested [NO_COLOR](https://no-color.org/) standards. Makes for cleaner exported logfiles.

So, `ref-builder --no-color otu create [ACCESSIONS]` will use the structlog JSON processor. The presence of a `NO_COLOR` environment variable will also disable coloured output.