### PR TITLE
feat: add access to indexed OTUs by acronym 

### DIFF
--- a/ref_builder/cli/utils.py
+++ b/ref_builder/cli/utils.py
@@ -14,9 +14,14 @@ def get_otu_from_identifier(repo: Repo, identifier: str) -> OTUBuilder:
     """Return an OTU id from the repo if identifier matches a single OTU.
 
     The identifier can either be a stringified UUIDv4, a truncated portion
-    of a UUID or a NCBI Taxonomy ID.
+    of a UUID, a NCBI Taxonomy ID or an acronym associated with the OTU.
 
     Raise a PartialIDConflictError if >1 OTU is found.
+
+    :param repo: the repository to be searched.
+    :param identifier: a non-UUID identifier.
+        Can be an integer Taxonomy ID, acronym or truncated partial UUID.
+    :return: the UUID of the OTU or ``None``
     """
     otu_id = None
 
@@ -35,6 +40,9 @@ def get_otu_from_identifier(repo: Repo, identifier: str) -> OTUBuilder:
             otu_id = repo.get_otu_id_by_taxid(taxid)
 
     else:
+        if (otu_id := repo.get_otu_id_by_acronym(identifier)) is not None:
+            return repo.get_otu(otu_id)
+
         try:
             otu_id = repo.get_otu_id_by_partial(identifier)
 

--- a/ref_builder/index.py
+++ b/ref_builder/index.py
@@ -255,8 +255,8 @@ class Index:
 
     def get_id_by_acronym(self, acronym: str) -> UUID | None:
         """Get an OTU ID by its acronym."""
-        if acronym == "":
-            return None
+        if not acronym:
+            raise ValueError("Acronym must contain at least one character.")
 
         cursor = self.con.execute(
             'SELECT id AS "id [uuid]" FROM otus WHERE acronym = ?',

--- a/ref_builder/index.py
+++ b/ref_builder/index.py
@@ -255,6 +255,9 @@ class Index:
 
     def get_id_by_acronym(self, acronym: str) -> UUID | None:
         """Get an OTU ID by its acronym."""
+        if acronym == "":
+            return None
+
         cursor = self.con.execute(
             'SELECT id AS "id [uuid]" FROM otus WHERE acronym = ?',
             (acronym,),

--- a/ref_builder/index.py
+++ b/ref_builder/index.py
@@ -253,6 +253,18 @@ class Index:
 
         return None
 
+    def get_id_by_acronym(self, acronym: str) -> UUID | None:
+        """Get an OTU ID by its acronym."""
+        cursor = self.con.execute(
+            'SELECT id AS "id [uuid]" FROM otus WHERE acronym = ?',
+            (acronym,),
+        )
+
+        if result := cursor.fetchone():
+            return result[0]
+
+        return None
+
     def get_id_by_legacy_id(self, legacy_id: str) -> UUID | None:
         """Get an OTU ID by its legacy ID."""
         cursor = self.con.execute(

--- a/ref_builder/repo.py
+++ b/ref_builder/repo.py
@@ -836,8 +836,17 @@ class Repo:
         :param acronym: the exact acronym of the OTU
         :return: the UUID of the OTU or ``None``
         """
+        try:
+            return self._index.get_id_by_acronym(acronym)
 
-        return self._index.get_id_by_acronym(acronym)
+        except ValueError as e:
+            logger.error(
+                "Bad input. Search acronym cannot be empty.",
+                acronym=acronym,
+                error=str(e),
+            )
+
+        return None
 
     def get_otu_id_by_taxid(self, taxid: int) -> uuid.UUID | None:
         """Return the UUID of the OTU with the given ``taxid``.

--- a/ref_builder/repo.py
+++ b/ref_builder/repo.py
@@ -829,6 +829,16 @@ class Repo:
 
         return None
 
+    def get_otu_id_by_acronym(self, acronym: str) -> uuid.UUID | None:
+        """Return the UUID of the OTU with the given ``acronym``.
+        If no OTU is found, return None.
+
+        :param acronym: the exact acronym of the OTU
+        :return: the UUID of the OTU or ``None``
+        """
+
+        return self._index.get_id_by_acronym(acronym)
+
     def get_otu_id_by_taxid(self, taxid: int) -> uuid.UUID | None:
         """Return the UUID of the OTU with the given ``taxid``.
 

--- a/tests/cli/test_print_commands.py
+++ b/tests/cli/test_print_commands.py
@@ -54,3 +54,10 @@ class TestPrintCommands:
             assert result.exit_code == 1
 
             assert "OTU not found" in result.output
+
+    def test_otu_get_empty(self, scratch_repo):
+        result = runner.invoke(otu_command_group, ["--path", str(scratch_repo.path)] + ["get", ""])
+
+        assert result.exit_code == 1
+
+        assert "OTU not found." in result.output

--- a/tests/cli/test_print_commands.py
+++ b/tests/cli/test_print_commands.py
@@ -56,7 +56,9 @@ class TestPrintCommands:
             assert "OTU not found" in result.output
 
     def test_otu_get_empty(self, scratch_repo):
-        result = runner.invoke(otu_command_group, ["--path", str(scratch_repo.path)] + ["get", ""])
+        result = runner.invoke(
+            otu_command_group, ["--path", str(scratch_repo.path)] + ["get", ""]
+        )
 
         assert result.exit_code == 1
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -7,7 +7,6 @@ from polyfactory.factories.pydantic_factory import ModelFactory
 from polyfactory.pytest_plugin import register_fixture
 from pydantic import BaseModel, TypeAdapter
 from pytest_mock import MockerFixture
-from structlog import get_logger
 
 from ref_builder.legacy.utils import build_legacy_otu
 from ref_builder.logs import configure_logger
@@ -29,8 +28,6 @@ from tests.fixtures.factories import (
 )
 
 configure_logger(True)
-
-logger = get_logger()
 
 
 @pytest.fixture(autouse=True)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -7,6 +7,7 @@ from polyfactory.factories.pydantic_factory import ModelFactory
 from polyfactory.pytest_plugin import register_fixture
 from pydantic import BaseModel, TypeAdapter
 from pytest_mock import MockerFixture
+from structlog import get_logger
 
 from ref_builder.legacy.utils import build_legacy_otu
 from ref_builder.logs import configure_logger
@@ -28,6 +29,8 @@ from tests.fixtures.factories import (
 )
 
 configure_logger(True)
+
+logger = get_logger()
 
 
 @pytest.fixture(autouse=True)

--- a/tests/test_index.py
+++ b/tests/test_index.py
@@ -179,6 +179,19 @@ class TestGetIDByPartial:
         assert index.get_id_by_partial("00000000") is None
 
 
+class TestGetIDByPartial:
+    """Test the `get_id_by_partial` method of the Snapshotter class."""
+
+    def test_ok(self, index: Index, indexable_otus: list[RepoOTU]):
+        """Test that the correct OTU ID is retrieved by a truncated partial."""
+        for otu in indexable_otus:
+            assert otu.id == index.get_id_by_partial(str(otu.id)[:8])
+
+    def test_not_found(self, index: Index):
+        """Test that `None` is returned when no matching ID is not found."""
+        assert index.get_id_by_partial("00000000") is None
+
+
 class TestGetIDByName:
     """Test the `get_id_by_name` method of the Snapshotter class."""
 

--- a/tests/test_index.py
+++ b/tests/test_index.py
@@ -192,6 +192,19 @@ class TestGetIDByPartial:
         assert index.get_id_by_partial("00000000") is None
 
 
+class TestGetIDByAcronym:
+    """Test the `get_id_by_name` method of the Snapshotter class."""
+
+    def test_ok(self, index: Index, indexable_otus: list[RepoOTU]):
+        """Test that the correct OTU ID is retrieved by acronym."""
+        for otu in indexable_otus:
+            assert otu.id == index.get_id_by_acronym(otu.acronym)
+
+    def test_not_found(self, index: Index):
+        """Test that `None` is returned when the acronym is not found."""
+        assert index.get_id_by_acronym("paella") is None
+
+
 class TestGetIDByName:
     """Test the `get_id_by_name` method of the Snapshotter class."""
 

--- a/tests/test_index.py
+++ b/tests/test_index.py
@@ -188,7 +188,10 @@ class TestGetIDByAcronym:
             assert otu.id == index.get_id_by_acronym(otu.acronym)
 
     def test_empty(self, index: Index, indexable_otus: list[OTUBuilder]):
-        assert index.get_id_by_acronym("") is None
+        with pytest.raises(
+            ValueError, match="Acronym must contain at least one character."
+        ):
+            index.get_id_by_acronym("")
 
     def test_not_found(self, index: Index):
         """Test that `None` is returned when the acronym is not found."""

--- a/tests/test_index.py
+++ b/tests/test_index.py
@@ -179,26 +179,16 @@ class TestGetIDByPartial:
         assert index.get_id_by_partial("00000000") is None
 
 
-class TestGetIDByPartial:
-    """Test the `get_id_by_partial` method of the Snapshotter class."""
-
-    def test_ok(self, index: Index, indexable_otus: list[RepoOTU]):
-        """Test that the correct OTU ID is retrieved by a truncated partial."""
-        for otu in indexable_otus:
-            assert otu.id == index.get_id_by_partial(str(otu.id)[:8])
-
-    def test_not_found(self, index: Index):
-        """Test that `None` is returned when no matching ID is not found."""
-        assert index.get_id_by_partial("00000000") is None
-
-
 class TestGetIDByAcronym:
-    """Test the `get_id_by_name` method of the Snapshotter class."""
+    """Test the `get_id_by_acronym` method of the Index class."""
 
-    def test_ok(self, index: Index, indexable_otus: list[RepoOTU]):
+    def test_ok(self, index: Index, indexable_otus: list[OTUBuilder]):
         """Test that the correct OTU ID is retrieved by acronym."""
         for otu in indexable_otus:
             assert otu.id == index.get_id_by_acronym(otu.acronym)
+
+    def test_empty(self, index: Index, indexable_otus: list[OTUBuilder]):
+        assert index.get_id_by_acronym("") is None
 
     def test_not_found(self, index: Index):
         """Test that `None` is returned when the acronym is not found."""

--- a/tests/test_repo.py
+++ b/tests/test_repo.py
@@ -676,15 +676,13 @@ class TestGetOTU:
         assert empty_repo.last_id == 9
 
     def test_acronym_ok(self, initialized_repo: Repo):
-        """Test that getting an OTU ID from the exact acronym of the OTU returns the expected ID.
-        """
+        """Test that getting an OTU ID from the exact acronym of the OTU returns the expected ID."""
         otu = next(initialized_repo.iter_otus())
 
         assert initialized_repo.get_otu_id_by_acronym("TMV") == otu.id
 
     def test_acronym_fail(self, initialized_repo: Repo):
-        """Test that a non-matching acronym cannot retrieve the OTU ID
-        """
+        """Test that a non-matching acronym cannot retrieve the OTU ID"""
         assert initialized_repo.get_otu_id_by_acronym("TM") is None
 
         assert initialized_repo.get_otu_id_by_acronym("TMVV") is None

--- a/tests/test_repo.py
+++ b/tests/test_repo.py
@@ -687,6 +687,15 @@ class TestGetOTU:
 
         assert initialized_repo.get_otu_id_by_acronym("TMVV") is None
 
+    def test_acronym_empty_fail(self, initialized_repo: Repo):
+        """Test that an attempt to search indexed OTUs using an empty acronym
+        logs an error message and returns None.
+        """
+        with capture_logs() as logs:
+            assert initialized_repo.get_otu_id_by_acronym("") is None
+
+        assert any(["Bad input" in log["event"] for log in logs])
+
     def test_partial_ok(self, initialized_repo: Repo):
         """Test that getting an OTU ID starting with a truncated 8-character portion
         returns an ID.

--- a/tests/test_repo.py
+++ b/tests/test_repo.py
@@ -675,6 +675,20 @@ class TestGetOTU:
 
         assert empty_repo.last_id == 9
 
+    def test_acronym_ok(self, initialized_repo: Repo):
+        """Test that getting an OTU ID from the exact acronym of the OTU returns the expected ID.
+        """
+        otu = next(initialized_repo.iter_otus())
+
+        assert initialized_repo.get_otu_id_by_acronym("TMV") == otu.id
+
+    def test_acronym_fail(self, initialized_repo: Repo):
+        """Test that a non-matching acronym cannot retrieve the OTU ID
+        """
+        assert initialized_repo.get_otu_id_by_acronym("TM") is None
+
+        assert initialized_repo.get_otu_id_by_acronym("TMVV") is None
+
     def test_partial_ok(self, initialized_repo: Repo):
         """Test that getting an OTU ID starting with a truncated 8-character portion
         returns an ID.


### PR DESCRIPTION
Add retrieve-by-acronym functionality to `cli.utils.get_otu_by_identifier()`

e.g. `ref-builder otu get ABTV` should return the data for Abaca bunchy top virus.

* add `Index.get_id_by_acronym()`
* add `Repo.get_otu_id_by_acronym()`