### PR TITLE
fix: segment length rounding errors

### DIFF
--- a/ref_builder/legacy/convert.py
+++ b/ref_builder/legacy/convert.py
@@ -1,4 +1,5 @@
 import json
+import math
 from collections import defaultdict
 from pathlib import Path
 
@@ -81,15 +82,23 @@ def convert_legacy_repo(name: str, path: Path, target_path: Path) -> None:
                 # Calculate tolerance based on min, max, and mean observed lengths.
                 length_tolerance = max(
                     0.01,
-                    (
-                        max(mean_length - min(lengths), max(lengths) - mean_length)
-                        / mean_length
+                    round(
+                        math.ceil(
+                            max(
+                                mean_length - min(lengths),
+                                max(lengths) - mean_length,
+                            )
+                            / mean_length
+                            * 100
+                        )
+                        / 100,
+                        ndigits=2,
                     ),
                 )
 
                 new_segment = Segment.new(
                     length=int(mean_length),
-                    length_tolerance=round(length_tolerance, 2),
+                    length_tolerance=length_tolerance,
                     name=name,
                     rule=SegmentRule.REQUIRED
                     if segment["required"]

--- a/ref_builder/otu/models.py
+++ b/ref_builder/otu/models.py
@@ -9,7 +9,7 @@ from ref_builder.utils import (
     IsolateName,
 )
 
-LegacyId = Annotated[str, Field(min_length=6, max_length=10, pattern=r"[A-Za-z0-9]+")]
+LegacyId = Annotated[str, Field(min_length=1, max_length=10, pattern=r"[A-Za-z0-9]+")]
 
 
 class SequenceModel(BaseModel):

--- a/ref_builder/otu/promote.py
+++ b/ref_builder/otu/promote.py
@@ -105,8 +105,8 @@ def promote_otu_accessions_from_records(
             replacement_record=records_by_promotable_sequence_id[sequence_id],
             exclude_accession=True,
         )
-
-        promoted_sequence_ids.add(promoted_sequence.id)
+        if promoted_sequence is not None:
+            promoted_sequence_ids.add(promoted_sequence.id)
 
         otu = repo.get_otu(otu.id)
 

--- a/ref_builder/otu/utils.py
+++ b/ref_builder/otu/utils.py
@@ -1,3 +1,4 @@
+import math
 import re
 from collections import Counter, defaultdict
 from enum import StrEnum
@@ -56,14 +57,16 @@ def get_segments_min_length(segments: list[Segment]) -> int:
     """Return the shortest minimum length from a list of segments."""
     shortest_segment = min(segments, key=lambda s: s.length)
 
-    return int(shortest_segment.length * (1.0 - shortest_segment.length_tolerance))
+    return math.floor(
+        shortest_segment.length * (1.0 - shortest_segment.length_tolerance)
+    )
 
 
 def get_segments_max_length(segments: list[Segment]) -> int:
     """Return the longest maximum length from a list of segments."""
     longest_segment = max(segments, key=lambda s: s.length)
 
-    return int(longest_segment.length * (1.0 + longest_segment.length_tolerance))
+    return math.ceil(longest_segment.length * (1.0 + longest_segment.length_tolerance))
 
 
 def check_sequence_length(sequence: str, segment_length: int, tolerance: float) -> bool:

--- a/ref_builder/otu/validators/otu.py
+++ b/ref_builder/otu/validators/otu.py
@@ -1,3 +1,4 @@
+import math
 import warnings
 from collections import Counter
 
@@ -165,8 +166,12 @@ class OTU(OTUBase):
                         },
                     )
 
-                min_length = int(segment.length * (1.0 - segment.length_tolerance))
-                max_length = int(segment.length * (1.0 + segment.length_tolerance))
+                min_length = math.floor(
+                    segment.length * (1.0 - segment.length_tolerance)
+                )
+                max_length = math.ceil(
+                    segment.length * (1.0 + segment.length_tolerance)
+                )
 
                 if len(sequence.sequence) < min_length:
                     raise PydanticCustomError(


### PR DESCRIPTION
Resolves an issue where `legacy.convert_legacy_repo()` occasionally created plan segments 1 character too tight (main fix in [ab549f0](https://github.com/ref-builder/ref-builder/pull/167/commits/ab547f0617e24fb965348ee429a5ec7ea9369880)).

* fix: handle a failed sequence promotion inside `otu.promote.promote_otu_accessions_from_records()` without tripping `AttributeError`
* fix: set `LegacyId` minimum length to 1, as legacy isolate ids can be very short