### PR TITLE
feat: add `DeleteOTU` event

### DIFF
--- a/ref_builder/cli/utils.py
+++ b/ref_builder/cli/utils.py
@@ -11,6 +11,8 @@ from ref_builder.utils import OTUDeletedWarning
 
 pass_repo = click.make_pass_decorator(Repo)
 
+UUID_STRING_LENGTH = 36
+
 
 def get_otu_from_identifier(repo: Repo, identifier: str) -> OTUBuilder:
     """Return an OTU id from the repo if identifier matches a single OTU.
@@ -27,7 +29,7 @@ def get_otu_from_identifier(repo: Repo, identifier: str) -> OTUBuilder:
     """
     otu_id = None
 
-    if len(identifier) == 32:
+    if len(identifier) == UUID_STRING_LENGTH:
         try:
             otu_id = UUID(identifier)
         except ValueError:

--- a/ref_builder/cli/utils.py
+++ b/ref_builder/cli/utils.py
@@ -1,4 +1,5 @@
 import sys
+import warnings
 from uuid import UUID
 
 import click
@@ -6,6 +7,7 @@ import click
 from ref_builder.errors import InvalidInputError, PartialIDConflictError
 from ref_builder.otu.builders.otu import OTUBuilder
 from ref_builder.repo import Repo
+from ref_builder.utils import OTUDeletedWarning
 
 pass_repo = click.make_pass_decorator(Repo)
 
@@ -62,8 +64,18 @@ def get_otu_from_identifier(repo: Repo, identifier: str) -> OTUBuilder:
         click.echo("OTU not found.", err=True)
         sys.exit(1)
 
-    if (otu_ := repo.get_otu(otu_id)) is None:
-        click.echo("OTU not found.", err=True)
+    with warnings.catch_warnings(
+        category=OTUDeletedWarning, record=True
+    ) as warning_list:
+        otu_ = repo.get_otu(otu_id)
+
+    if otu_ is None:
+        if warning_list:
+            click.echo("OTU has been deleted.", err=True)
+
+        else:
+            click.echo("OTU not found.", err=True)
+
         sys.exit(1)
 
     return otu_

--- a/ref_builder/errors.py
+++ b/ref_builder/errors.py
@@ -1,3 +1,6 @@
+from uuid import UUID
+
+
 class LockConflictError(Exception):
     """Raised when a lock is attempted on a locked repository."""
 
@@ -40,3 +43,10 @@ class InvalidInputError(Exception):
         self.message = message
 
         super().__init__(message)
+
+
+class OTUDeletedError(Exception):
+    """Raised when an OTU is deleted."""
+
+    def __init__(self, otu_id: UUID):
+        super().__init__(f"OTU {otu_id} has been marked for deletion.")

--- a/ref_builder/events/otu.py
+++ b/ref_builder/events/otu.py
@@ -59,6 +59,20 @@ class CreatePlan(ApplicableEvent):
         return otu
 
 
+class DeleteOTUData(EventData):
+    """The data for a :class:`DeleteOTU` event."""
+
+    rationale: str
+    replacement_otu_id: UUID4 | None
+
+
+class DeleteOTU(Event):
+    """An event that deletes an OTU from Repo indexes."""
+
+    data: DeleteOTUData
+    query: OTUQuery
+
+
 class SetRepresentativeIsolateData(EventData):
     """The data for a :class:`SetReprIsolate` event."""
 

--- a/ref_builder/index.py
+++ b/ref_builder/index.py
@@ -351,17 +351,18 @@ class Index:
 
         return None
 
-    def delete_otu(self, otu_id: UUID) -> None:
+    def delete_otu(self, otu_id: UUID, delete_from_event_index: bool = True) -> None:
         """Remove an OTU from the index.
 
         This happens rarely, so we just rewrite the whole index.
 
         :param otu_id: the ID of the OTU to remove.
         """
-        self.con.execute(
-            "DELETE FROM events WHERE otu_id = ?",
-            (otu_id,),
-        )
+        if delete_from_event_index:
+            self.con.execute(
+                "DELETE FROM events WHERE otu_id = ?",
+                (otu_id,),
+            )
 
         self.con.execute(
             "DELETE FROM isolates WHERE otu_id = ?",

--- a/ref_builder/index.py
+++ b/ref_builder/index.py
@@ -351,19 +351,13 @@ class Index:
 
         return None
 
-    def delete_otu(self, otu_id: UUID, delete_from_event_index: bool = True) -> None:
+    def delete_otu(self, otu_id: UUID) -> None:
         """Remove an OTU from the index.
 
         This happens rarely, so we just rewrite the whole index.
 
         :param otu_id: the ID of the OTU to remove.
         """
-        if delete_from_event_index:
-            self.con.execute(
-                "DELETE FROM events WHERE otu_id = ?",
-                (otu_id,),
-            )
-
         self.con.execute(
             "DELETE FROM isolates WHERE otu_id = ?",
             (otu_id,),

--- a/ref_builder/repo.py
+++ b/ref_builder/repo.py
@@ -343,7 +343,11 @@ class Repo:
 
         for event in self._event_store.iter_events():
             if hasattr(event.query, "otu_id"):
-                event_ids_by_otu[event.query.otu_id].append(event.id)
+                if isinstance(event, DeleteOTU):
+                    event_ids_by_otu.pop(event.query.otu_id)
+
+                else:
+                    event_ids_by_otu[event.query.otu_id].append(event.id)
 
         for otu_id in event_ids_by_otu:
             yield self._rehydrate_otu(

--- a/ref_builder/repo.py
+++ b/ref_builder/repo.py
@@ -792,6 +792,11 @@ class Repo:
 
             otu = self._rehydrate_otu(events)
 
+        except OTUDeletedError as e:
+            logger.error("Requested OTU has been deleted from the Repo.", msg=e)
+
+            return None
+
         except FileNotFoundError:
             logger.error("Event exists in index, but not in source. Deleting index...")
 

--- a/ref_builder/repo.py
+++ b/ref_builder/repo.py
@@ -28,6 +28,7 @@ from structlog import get_logger
 from ref_builder.errors import (
     InvalidInputError,
     LockRequiredError,
+    OTUDeletedError,
     TransactionExistsError,
     TransactionRequiredError,
 )
@@ -57,6 +58,7 @@ from ref_builder.events.otu import (
     CreateOTUData,
     CreatePlan,
     CreatePlanData,
+    DeleteOTU,
     SetRepresentativeIsolate,
     SetRepresentativeIsolateData,
     UpdateExcludedAccessions,
@@ -957,6 +959,9 @@ class Repo:
                 )
 
             for event in events:
+                if isinstance(event, DeleteOTU):
+                    raise OTUDeletedError(otu_id=event.query.otu_id)
+
                 if not isinstance(event, ApplicableEvent):
                     raise TypeError(
                         f"Event {event.id} {event.type} is not an applicable event."

--- a/ref_builder/repo.py
+++ b/ref_builder/repo.py
@@ -420,7 +420,7 @@ class Repo:
     ) -> bool:
         """Delete an OTU from the repository. Return True if successful."""
         if self.get_otu(otu_id) is None:
-            logger.warning("OTU does not exist.")
+            logger.error("Requested OTU id does not exist.", otu_id=str(otu_id))
 
             return False
 
@@ -440,7 +440,7 @@ class Repo:
             OTUQuery(otu_id=otu_id),
         )
 
-        self._index.delete_otu(otu_id)
+        self._index.delete_otu(otu_id, delete_from_event_index=False)
 
         otu = self.get_otu(otu_id)
 

--- a/ref_builder/repo.py
+++ b/ref_builder/repo.py
@@ -848,7 +848,11 @@ class Repo:
             otu = self._rehydrate_otu(events)
 
         except OTUDeletedError:
-            warnings.warn(OTUDeletedWarning)
+            warnings.warn(
+                f"OTU {otu_id} has already been deleted.",
+                category=OTUDeletedWarning,
+                stacklevel=1,
+            )
 
             return None
 

--- a/ref_builder/repo.py
+++ b/ref_builder/repo.py
@@ -419,7 +419,12 @@ class Repo:
         replacement_otu_id: uuid.UUID | None,
     ) -> bool:
         """Delete an OTU from the repository. Return True if successful."""
-        if self.get_otu(otu_id) is None:
+        with warnings.catch_warnings(category=OTUDeletedWarning):
+            warnings.simplefilter("ignore", OTUDeletedWarning)
+
+            otu_ = self.get_otu(otu_id)
+
+        if otu_ is None:
             logger.error("Requested OTU id does not exist.", otu_id=str(otu_id))
 
             return False
@@ -442,9 +447,10 @@ class Repo:
 
         self._index.delete_otu(otu_id, delete_from_event_index=False)
 
-        otu = self.get_otu(otu_id)
+        with warnings.catch_warnings(category=OTUDeletedWarning):
+            warnings.simplefilter("ignore", OTUDeletedWarning)
 
-        return otu is None
+            return self.get_otu(otu_id) is None
 
     def create_isolate(
         self,

--- a/ref_builder/repo.py
+++ b/ref_builder/repo.py
@@ -445,7 +445,7 @@ class Repo:
             OTUQuery(otu_id=otu_id),
         )
 
-        self._index.delete_otu(otu_id, delete_from_event_index=False)
+        self._index.delete_otu(otu_id)
 
         with warnings.catch_warnings(category=OTUDeletedWarning):
             warnings.simplefilter("ignore", OTUDeletedWarning)

--- a/ref_builder/store.py
+++ b/ref_builder/store.py
@@ -13,6 +13,7 @@ from ref_builder.events.isolate import (
 from ref_builder.events.otu import (
     CreateOTU,
     CreatePlan,
+    DeleteOTU,
     SetRepresentativeIsolate,
     UpdateExcludedAccessions,
 )
@@ -127,6 +128,7 @@ class EventStore:
                     "LinkSequence": LinkSequence,
                     "UnlinkSequence": UnlinkSequence,
                     "DeleteIsolate": DeleteIsolate,
+                    "DeleteOTU": DeleteOTU,
                     "DeleteSequence": DeleteSequence,
                     "CreatePlan": CreatePlan,
                     "SetRepresentativeIsolate": SetRepresentativeIsolate,

--- a/ref_builder/utils.py
+++ b/ref_builder/utils.py
@@ -12,6 +12,10 @@ GENBANK_ACCESSION_PATTERN = re.compile(pattern=r"^[A-Z]{1,2}[0-9]{5,6}$")
 REFSEQ_ACCESSION_PATTERN = re.compile(pattern=r"^NC_[0-9]{6}$")
 
 
+class OTUDeletedWarning(UserWarning):
+    """A warning raised when a previously deleted OTU is requested."""
+
+
 @dataclass(frozen=True)
 class Accession:
     """A Genbank accession number."""

--- a/tests/cli/test_otu_commands.py
+++ b/tests/cli/test_otu_commands.py
@@ -51,9 +51,9 @@ class TestCreateOTUCommands:
 
     @pytest.mark.parametrize(
         ("taxid", "accessions"),
-        [(1278205, ["NC_020160"]), (345184, ["DQ178610", "DQ178611"])],
+        [(3429802, ["NC_020160"]), (3426695, ["DQ178610", "DQ178611"])],
     )
-    def test_without_taxid_ok(
+    def test_without_taxid(
         self,
         taxid: int,
         accessions: list[str],
@@ -62,7 +62,7 @@ class TestCreateOTUCommands:
         """Test that an OTU can be created without the --taxid option."""
         result = runner.invoke(
             otu_command_group,
-            ["--path", str(precached_repo.path)] + ["create"] + accessions,
+            ["--path", str(precached_repo.path), "create", *accessions],
         )
 
         assert result.exit_code == 0

--- a/tests/cli/test_print_commands.py
+++ b/tests/cli/test_print_commands.py
@@ -49,8 +49,6 @@ class TestPrintCommands:
                 replacement_otu_id=None,
             )
 
-        assert scratch_repo.get_otu(otu_id) is None
-
         result = runner.invoke(
             otu_command_group,
             ["--path", str(scratch_repo.path)] + ["get", str(otu_id)],

--- a/tests/cli/test_print_commands.py
+++ b/tests/cli/test_print_commands.py
@@ -1,97 +1,83 @@
-from uuid import uuid4
-
 from click.testing import CliRunner
 
 from ref_builder.cli.otu import otu as otu_command_group
+from ref_builder.repo import Repo
 
 runner = CliRunner()
 
 
-class TestPrintCommands:
+def test_otu_list(scratch_repo: Repo):
+    result = runner.invoke(
+        otu_command_group,
+        ["--path", str(scratch_repo.path)] + ["list"],
+    )
+
+    assert result.exit_code == 0
+
+
+class TestOTUGet:
     """Test otu console printing commands."""
 
-    def test_otu_list(self, scratch_repo):
-        result = runner.invoke(
-            otu_command_group,
-            ["--path", str(scratch_repo.path)] + ["list"],
-        )
-
-        assert result.exit_code == 0
-
-    def test_otu_get_ok(self, scratch_repo):
+    def test_plain(self, scratch_repo: Repo):
         for otu_ in scratch_repo.iter_otus():
             result = runner.invoke(
                 otu_command_group,
                 ["--path", str(scratch_repo.path)] + ["get", str(otu_.id)],
             )
 
+            if result.exit_code != 0:
+                print(result.output)
+
             assert result.exit_code == 0
 
-    def test_otu_get_nonexistent_fail(self, scratch_repo):
-        """Test that otu get command on a nonexistent OTU id fails with expected error text."""
-        result = runner.invoke(
-            otu_command_group,
-            ["--path", str(scratch_repo.path)] + ["get", str(uuid4())],
-        )
-
-        assert result.exit_code == 1
-
-        assert "OTU not found" in result.output
-
-    def test_otu_get_deleted_fail(self, scratch_repo):
-        """Test that otu get command on a deleted OTU id fails with expected error text."""
-        otu_id = scratch_repo.get_otu_id_by_taxid(438782)
-
-        with scratch_repo.lock(), scratch_repo.use_transaction():
-            scratch_repo.delete_otu(
-                otu_id,
-                rationale="Removing OTU for testing purposes",
-                replacement_otu_id=None,
-            )
-
-        result = runner.invoke(
-            otu_command_group,
-            ["--path", str(scratch_repo.path)] + ["get", str(otu_id)],
-        )
-
-        assert result.exit_code == 1
-
-        assert "OTU has been deleted" in result.output
-
-    def test_otu_get_json_ok(self, scratch_repo):
+    def test_json(self, scratch_repo: Repo):
+        """Test otu console printing commands with JSON output."""
         for otu_ in scratch_repo.iter_otus():
             result = runner.invoke(
                 otu_command_group,
                 ["--path", str(scratch_repo.path)] + ["get", str(otu_.id), "--json"],
             )
 
+            if result.exit_code != 0:
+                print(result.output)
+
             assert result.exit_code == 0
 
-    def test_otu_partial_ok(self, scratch_repo):
+    def test_partial_id(self, scratch_repo: Repo):
+        """Test that a partial ID can be used to retrieve OTUs."""
         for otu_ in scratch_repo.iter_otus():
             result = runner.invoke(
                 otu_command_group,
                 ["--path", str(scratch_repo.path)] + ["get", str(otu_.id)[:8]],
             )
 
+            if result.exit_code != 0:
+                print(result.output)
+
             assert result.exit_code == 0
 
-    def test_otu_partial_too_short(self, scratch_repo):
+    def test_otu_partial_too_short(self, scratch_repo: Repo):
+        """Test that a partial ID that is too short raises an error."""
         for otu_ in scratch_repo.iter_otus():
             result = runner.invoke(
                 otu_command_group,
                 ["--path", str(scratch_repo.path)] + ["get", str(otu_.id)[:5]],
             )
 
-            assert result.exit_code == 1
+            if result.exit_code != 1:
+                print(result.output)
 
+            assert result.exit_code == 1
             assert "OTU not found" in result.output
 
-    def test_otu_get_empty(self, scratch_repo):
+    def test_empty(self, scratch_repo):
+        """Test that an empty ID string raises an error."""
         result = runner.invoke(
             otu_command_group, ["--path", str(scratch_repo.path)] + ["get", ""]
         )
 
-        assert result.exit_code == 1
+        if result.exit_code != 1:
+            print(result.output)
 
+        assert result.exit_code == 1
         assert "OTU not found." in result.output

--- a/tests/cli/test_print_commands.py
+++ b/tests/cli/test_print_commands.py
@@ -1,7 +1,8 @@
+from uuid import uuid4
+
 from click.testing import CliRunner
 
 from ref_builder.cli.otu import otu as otu_command_group
-
 
 runner = CliRunner()
 
@@ -25,6 +26,39 @@ class TestPrintCommands:
             )
 
             assert result.exit_code == 0
+
+    def test_otu_get_nonexistent_fail(self, scratch_repo):
+        """Test that otu get command on a nonexistent OTU id fails with expected error text."""
+        result = runner.invoke(
+            otu_command_group,
+            ["--path", str(scratch_repo.path)] + ["get", str(uuid4())],
+        )
+
+        assert result.exit_code == 1
+
+        assert "OTU not found" in result.output
+
+    def test_otu_get_deleted_fail(self, scratch_repo):
+        """Test that otu get command on a deleted OTU id fails with expected error text."""
+        otu_id = scratch_repo.get_otu_id_by_taxid(438782)
+
+        with scratch_repo.lock(), scratch_repo.use_transaction():
+            scratch_repo.delete_otu(
+                otu_id,
+                rationale="Removing OTU for testing purposes",
+                replacement_otu_id=None,
+            )
+
+        assert scratch_repo.get_otu(otu_id) is None
+
+        result = runner.invoke(
+            otu_command_group,
+            ["--path", str(scratch_repo.path)] + ["get", str(otu_id)],
+        )
+
+        assert result.exit_code == 1
+
+        assert "OTU has been deleted" in result.output
 
     def test_otu_get_json_ok(self, scratch_repo):
         for otu_ in scratch_repo.iter_otus():

--- a/tests/ncbi/__snapshots__/test_client.ambr
+++ b/tests/ncbi/__snapshots__/test_client.ambr
@@ -64,6 +64,11 @@
         'name': 'Begomovirus',
         'rank': 'genus',
       }),
+      dict({
+        'id': 3426821,
+        'name': 'Begomovirus jacquemontiayucatanense',
+        'rank': 'species',
+      }),
     ]),
     'name': 'Jacquemontia mosaic Yucatan virus',
     'other_names': dict({
@@ -78,10 +83,10 @@
       'synonym': list([
       ]),
     }),
-    'rank': <NCBIRank.SPECIES: 'species'>,
+    'rank': <NCBIRank.NO_RANK: 'no rank'>,
     'species': dict({
-      'id': 1198450,
-      'name': 'Jacquemontia mosaic Yucatan virus',
+      'id': 3426821,
+      'name': 'Begomovirus jacquemontiayucatanense',
       'rank': 'species',
     }),
   })

--- a/tests/test_add.py
+++ b/tests/test_add.py
@@ -52,11 +52,11 @@ class TestCreateOTU:
     @pytest.mark.parametrize(
         ("accessions", "expected_taxid"),
         [
-            (["DQ178610", "DQ178611"], 345184),
+            (["DQ178610", "DQ178611"], 3426695),
             (["NC_043170"], 3240630),
         ],
     )
-    def test_create_without_taxid_ok(self, accessions, expected_taxid, precached_repo):
+    def test_create_without_taxid(self, accessions, expected_taxid, precached_repo):
         with precached_repo.lock():
             made_otu = create_otu_without_taxid(
                 precached_repo, accessions=accessions, acronym=""

--- a/tests/test_repo.py
+++ b/tests/test_repo.py
@@ -779,6 +779,15 @@ def test_get_otu_id_from_isolate_id(initialized_repo: Repo):
     assert initialized_repo.get_otu_id_by_isolate_id(isolate.id) == otu.id
 
 
+class TestDeleteOTU:
+    """Test OTU deletion."""
+
+    def test_ok(self, initialized_repo: Repo):
+        otu_before = next(initialized_repo.iter_otus())
+
+        assert isinstance(otu_before, OTUBuilder)
+
+
 class TestGetIsolate:
     def test_by_id(self, initialized_repo: Repo):
         """Test that getting an isolate returns the expected ``IsolateBuilder`` object."""


### PR DESCRIPTION
Allows for the removal of an OTU from repo iteration and indexes.

Event records remain in the `events` table for posterity.

* add `DeleteOTU` event
* add `errors.OTUDeletedError`
* add `test_repo::TestDeleteOTU`