### PR TITLE
feat: add `UpdateIdentifiers` event

### DIFF
--- a/ref_builder/events/otu.py
+++ b/ref_builder/events/otu.py
@@ -112,3 +112,31 @@ class UpdateExcludedAccessions(ApplicableEvent):
                 otu.excluded_accessions.add(accession)
 
         return otu
+
+
+class UpdateIdentifiersData(EventData):
+    """The data for an UpdateIdentifiers event."""
+
+    taxid: int | None
+    name: str | None
+
+
+class UpdateIdentifiers(ApplicableEvent):
+    """An event that changes an OTU's Taxonomy ID or name.
+
+    This event is emitted when an OTU's taxonomical data undergoes minor changes,
+    such as assignment to a new species name.
+    """
+
+    data: UpdateIdentifiersData
+    query: OTUQuery
+
+    def apply(self, otu: OTUBuilder) -> OTUBuilder:
+        """Update the OTU's Taxonomy ID and/or name and return."""
+        if self.data.taxid is not None:
+            otu.taxid = self.data.taxid
+
+        if self.data.name is not None:
+            otu.name = self.data.name
+
+        return otu

--- a/ref_builder/otu/modify.py
+++ b/ref_builder/otu/modify.py
@@ -78,6 +78,7 @@ def allow_accessions_into_otu(
             excluded_accessions=sorted(excluded_accessions),
         )
 
+
 def update_otu_identifiers(
     repo: Repo,
     otu: OTUBuilder,

--- a/ref_builder/repo.py
+++ b/ref_builder/repo.py
@@ -61,6 +61,8 @@ from ref_builder.events.otu import (
     SetRepresentativeIsolateData,
     UpdateExcludedAccessions,
     UpdateExcludedAccessionsData,
+    UpdateIdentifiers,
+    UpdateIdentifiersData,
 )
 from ref_builder.events.repo import (
     CreateRepo,
@@ -610,6 +612,32 @@ class Repo:
         return (
             self.get_otu(otu_id).get_isolate(isolate_id).get_sequence_by_id(sequence_id)
         )
+
+    def update_otu_identifiers(
+        self,
+        otu_id: uuid.UUID,
+        taxid: int | None,
+        name: str | None,
+    ) -> OTUBuilder | None:
+        """Set the Taxonomy ID or name of an OTU."""
+        otu = self.get_otu(otu_id)
+
+        if taxid == otu.taxid:
+            logger.warning("Taxonomy ID is already up to date.")
+            taxid = None
+
+        if name == otu.name:
+            logger.warning("Name is already up to date.")
+            name = None
+
+        if any([taxid, name]) is not None:
+            self._write_event(
+                UpdateIdentifiers,
+                UpdateIdentifiersData(taxid=taxid, name=name),
+                OTUQuery(otu_id=otu.id),
+            )
+
+        return self.get_otu(otu_id)
 
     def set_representative_isolate(
         self, otu_id: uuid.UUID, isolate_id: uuid.UUID

--- a/ref_builder/store.py
+++ b/ref_builder/store.py
@@ -34,6 +34,7 @@ CLASS_NAME_INDEX = {
     "CreatePlan": CreatePlan,
     "SetRepresentativeIsolate": SetRepresentativeIsolate,
     "UpdateExcludedAccessions": UpdateExcludedAccessions,
+    "UpdateIdentifiers": UpdateIdentifiers,
 }
 
 

--- a/ref_builder/store.py
+++ b/ref_builder/store.py
@@ -15,10 +15,26 @@ from ref_builder.events.otu import (
     CreatePlan,
     SetRepresentativeIsolate,
     UpdateExcludedAccessions,
+    UpdateIdentifiers,
 )
 from ref_builder.events.repo import CreateRepo
 from ref_builder.events.sequence import CreateSequence, DeleteSequence
 from ref_builder.utils import pad_zeroes
+
+
+CLASS_NAME_INDEX = {
+    "CreateRepo": CreateRepo,
+    "CreateOTU": CreateOTU,
+    "CreateIsolate": CreateIsolate,
+    "CreateSequence": CreateSequence,
+    "LinkSequence": LinkSequence,
+    "UnlinkSequence": UnlinkSequence,
+    "DeleteIsolate": DeleteIsolate,
+    "DeleteSequence": DeleteSequence,
+    "CreatePlan": CreatePlan,
+    "SetRepresentativeIsolate": SetRepresentativeIsolate,
+    "UpdateExcludedAccessions": UpdateExcludedAccessions,
+}
 
 
 class EventStore:
@@ -119,19 +135,7 @@ class EventStore:
             loaded = orjson.loads(f.read())
 
             try:
-                cls = {
-                    "CreateRepo": CreateRepo,
-                    "CreateOTU": CreateOTU,
-                    "CreateIsolate": CreateIsolate,
-                    "CreateSequence": CreateSequence,
-                    "LinkSequence": LinkSequence,
-                    "UnlinkSequence": UnlinkSequence,
-                    "DeleteIsolate": DeleteIsolate,
-                    "DeleteSequence": DeleteSequence,
-                    "CreatePlan": CreatePlan,
-                    "SetRepresentativeIsolate": SetRepresentativeIsolate,
-                    "UpdateExcludedAccessions": UpdateExcludedAccessions,
-                }[loaded["type"]]
+                cls = CLASS_NAME_INDEX[loaded["type"]]
 
                 return cls(**loaded)
 

--- a/tests/test_repo.py
+++ b/tests/test_repo.py
@@ -852,11 +852,11 @@ class TestUpdateIdentifiers:
                 otu_init.id, taxid=dummy_taxid, name=dummy_name,
             )
 
-        otu_after = initialized_repo.get_otu(otu_init.id)
-
         assert initialized_repo.get_otu_by_taxid(otu_init.taxid) is None
 
-        assert initialized_repo.get_otu_by_taxid(dummy_taxid).id == otu_init.id
+        assert (
+            otu_after := initialized_repo.get_otu_by_taxid(dummy_taxid)
+        ) is not None
 
         assert otu_after.taxid == dummy_taxid
 

--- a/tests/test_repo.py
+++ b/tests/test_repo.py
@@ -847,20 +847,28 @@ class TestUpdateIdentifiers:
 
         dummy_name = "Dummy name"
 
+        isolate_id = otu_init.representative_isolate
+
+        assert isolate_id is not None
+
+        assert initialized_repo.get_otu_id_by_isolate_id(isolate_id) == otu_init.id
+
         with initialized_repo.lock(), initialized_repo.use_transaction():
             initialized_repo.update_otu_identifiers(
-                otu_init.id, taxid=dummy_taxid, name=dummy_name,
+                otu_init.id,
+                taxid=dummy_taxid,
+                name=dummy_name,
             )
 
         assert initialized_repo.get_otu_by_taxid(otu_init.taxid) is None
 
-        assert (
-            otu_after := initialized_repo.get_otu_by_taxid(dummy_taxid)
-        ) is not None
+        assert (otu_after := initialized_repo.get_otu_by_taxid(dummy_taxid)) is not None
 
         assert otu_after.taxid == dummy_taxid
 
         assert otu_after.name == dummy_name
+
+        assert initialized_repo.get_otu_id_by_isolate_id(isolate_id) == otu_after.id
 
 
 def test_get_isolate_id_from_partial(initialized_repo: Repo):

--- a/tests/test_repo.py
+++ b/tests/test_repo.py
@@ -839,6 +839,30 @@ class TestGetIsolate:
         assert isolate_unnamed_after.accessions == {"NP000001"}
 
 
+class TestUpdateIdentifiers:
+    def test_ok(self, initialized_repo: Repo):
+        otu_init = next(initialized_repo.iter_otus())
+
+        dummy_taxid = 34612644
+
+        dummy_name = "Dummy name"
+
+        with initialized_repo.lock(), initialized_repo.use_transaction():
+            initialized_repo.update_otu_identifiers(
+                otu_init.id, taxid=dummy_taxid, name=dummy_name,
+            )
+
+        otu_after = initialized_repo.get_otu(otu_init.id)
+
+        assert initialized_repo.get_otu_by_taxid(otu_init.taxid) is None
+
+        assert initialized_repo.get_otu_by_taxid(dummy_taxid).id == otu_init.id
+
+        assert otu_after.taxid == dummy_taxid
+
+        assert otu_after.name == dummy_name
+
+
 def test_get_isolate_id_from_partial(initialized_repo: Repo):
     """Test that an isolate id can be retrieved from a truncated ``partial`` string."""
     otu = next(initialized_repo.iter_otus())


### PR DESCRIPTION
Allows later modification of `OTU.name` and `OTU.taxid`. 

* add `event.otu.UpdateIdentifiers` event
* add `Repo.update_otu_identifiers()`
* add `test_repo::TestUpdateIdentifiers`