### PR TITLE
feat: make sequence promotion and update dedicated events

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,5 +8,5 @@ __pycache__
 dist
 scratch
 Thumbs.db
-TODO.md
+TODO*.md
 venv

--- a/ref_builder/store.py
+++ b/ref_builder/store.py
@@ -13,7 +13,9 @@ from ref_builder.events.isolate import (
 from ref_builder.events.otu import (
     CreateOTU,
     CreatePlan,
+    PromoteSequence,
     UpdateExcludedAccessions,
+    UpdateSequence,
 )
 from ref_builder.events.repo import CreateRepo
 from ref_builder.events.sequence import CreateSequence, DeleteSequence
@@ -128,7 +130,9 @@ class EventStore:
                     "DeleteIsolate": DeleteIsolate,
                     "DeleteSequence": DeleteSequence,
                     "CreatePlan": CreatePlan,
+                    "PromoteSequence": PromoteSequence,
                     "UpdateExcludedAccessions": UpdateExcludedAccessions,
+                    "UpdateSequence": UpdateSequence,
                 }[loaded["type"]]
 
                 return cls(**loaded)

--- a/tests/test_repo.py
+++ b/tests/test_repo.py
@@ -1153,43 +1153,6 @@ class TestDeleteIsolate:
         assert initialized_repo.last_id == event_id_before_delete + 1
 
 
-def test_replace_sequence(initialized_repo: Repo):
-    """Test the replacement of an existing sequence using a new Genbank accession and
-    record.
-    """
-    otu_init = initialized_repo.get_otu_by_taxid(3432891)
-
-    replaceable_sequence = otu_init.get_sequence_by_accession("TM000001")
-
-    isolate_id = next(
-        iter(otu_init.get_isolate_ids_containing_sequence_id(replaceable_sequence.id))
-    )
-
-    with initialized_repo.lock():
-        with initialized_repo.use_transaction():
-            new_sequence = initialized_repo.create_sequence(
-                otu_init.id,
-                "RP000001.1",
-                "TMV edit",
-                otu_init.plan.segments[0].id,
-                "TACGTGGAGAGACCA",
-            )
-
-        with initialized_repo.use_transaction():
-            initialized_repo.replace_sequence(
-                otu_id=otu_init.id,
-                isolate_id=isolate_id,
-                sequence_id=new_sequence.id,
-                replaced_sequence_id=replaceable_sequence.id,
-                rationale="Testing sequence redaction",
-            )
-
-        otu_after = initialized_repo.get_otu(otu_init.id)
-
-    assert otu_after.get_sequence_by_id(new_sequence.id) is not None
-    assert otu_after.get_sequence_by_id(replaceable_sequence.id) is None
-
-
 class TestMalformedEvent:
     """Test that malformed events cannot be rehydrated."""
 


### PR DESCRIPTION
## Summary

Refactored sequence promotion and version updates to use dedicated event types, improving the event log clarity and maintainability:

- Created `PromoteSequence` event for GenBank → RefSeq promotions that handles sequence replacement across all isolates, deletion of old sequence, and exclusion of old accession
- Created `UpdateSequence` event for version updates (e.g., .1 → .2) that handles sequence replacement and deletion but does not exclude accessions since the key remains the same
- Simplified promotion logic by consolidating multi-isolate replacement logic into the event application layer
- Removed `replace_sequence()` method in favor of dedicated `promote_sequence()` and `update_sequence()` methods
- Removed complex sequence replacement logic that operated at the isolate level