### PR TITLE
perf: rebuild OTU lookups lazily during rehydration

### DIFF
--- a/ref_builder/events/isolate.py
+++ b/ref_builder/events/isolate.py
@@ -52,6 +52,8 @@ class DeleteIsolate(ApplicableEvent[DeleteIsolateData, IsolateQuery]):
 
     def apply(self, otu: OTU) -> OTU:
         """Delete the specified isolate and return."""
+        otu.rebuild_lookups()
+
         if otu.get_isolate(self.query.isolate_id) is None:
             raise HydrationIsolateError("Could not find referenced isolate.")
 
@@ -112,6 +114,8 @@ class PromoteIsolate(ApplicableEvent[PromoteIsolateData, IsolateQuery]):
         4. Remove old GenBank sequences from the isolate
         5. Mark old accessions as excluded
         """
+        otu.rebuild_lookups()
+
         isolate = otu.get_isolate(self.query.isolate_id)
 
         if isolate is None:

--- a/ref_builder/repo.py
+++ b/ref_builder/repo.py
@@ -650,7 +650,6 @@ class Repo:
                     )
 
                 otu = event.apply(otu)
-                otu.rebuild_lookups()
 
         for warning_msg in warning_list:
             logger.warning(

--- a/tests/ncbi/__snapshots__/test_client.ambr
+++ b/tests/ncbi/__snapshots__/test_client.ambr
@@ -31,7 +31,7 @@
       }),
       dict({
         'id': 2731342,
-        'name': 'Monodnaviria',
+        'name': 'Floreoviria',
         'rank': 'realm',
       }),
       dict({


### PR DESCRIPTION
## Summary
- Moves `rebuild_lookups()` calls from a central location in `repo.py` (called after every event) to only specific events that require it (`DeleteIsolate` and `PromoteIsolate`)
- This makes lookup rebuilding lazy — only triggered when actually needed rather than unconditionally after each event application, reducing unnecessary work during rehydration of large OTUs

## Test plan
- [ ] Run the existing test suite to verify no regressions in OTU rehydration behavior
- [ ] Test with a large OTU repository to confirm performance improvement during rehydration
- [ ] Verify `DeleteIsolate` and `PromoteIsolate` events still correctly rebuild lookups before operating