### PR TITLE
fix: detect and prevent duplicate accessions across and within OTUs

### DIFF
--- a/ref_builder/audit.py
+++ b/ref_builder/audit.py
@@ -1,0 +1,94 @@
+"""Lightweight, validator-bypassing OTU snapshots used by audit tooling.
+
+The OTU model now refuses to construct when it contains duplicate accessions
+within an isolate. That guarantees future repos cannot be corrupted in that
+way, but it also means an already-corrupt repo can no longer be loaded via
+the normal hydration path. The audit machinery here walks events directly via
+``Repo.iter_otu_audit_snapshots`` so existing corruption can still be surfaced.
+"""
+
+from collections import defaultdict
+from dataclasses import dataclass, field
+from typing import TYPE_CHECKING
+from uuid import UUID
+
+if TYPE_CHECKING:
+    from ref_builder.repo import Repo
+
+MIN_OCCURRENCES_FOR_DUPLICATE = 2
+
+
+@dataclass
+class IsolateAuditSnapshot:
+    """Per-isolate audit data; ``accession_keys`` is a list so duplicates persist."""
+
+    id: UUID
+    name: str | None
+    accession_keys: list[str] = field(default_factory=list)
+
+
+@dataclass
+class OTUAuditSnapshot:
+    """Per-OTU audit data extracted directly from events."""
+
+    id: UUID
+    taxid: int
+    name: str
+    isolates: list[IsolateAuditSnapshot]
+
+
+@dataclass
+class AccessionPlacement:
+    """Where a single accession occurrence lives."""
+
+    otu_id: UUID
+    otu_name: str
+    otu_taxid: int
+    isolate_id: UUID
+    isolate_name: str | None
+
+
+@dataclass
+class AccessionAuditReport:
+    """Findings from a repo-wide accession scan."""
+
+    cross_otu: dict[str, list[AccessionPlacement]]
+    within_otu: dict[str, list[AccessionPlacement]]
+
+    @property
+    def has_findings(self) -> bool:
+        """True if either kind of duplicate was found."""
+        return bool(self.cross_otu or self.within_otu)
+
+
+def audit_accessions(repo: "Repo") -> AccessionAuditReport:
+    """Scan a repo for cross-OTU and within-OTU duplicate accessions."""
+    placements: dict[str, list[AccessionPlacement]] = defaultdict(list)
+
+    for otu in repo.iter_otu_audit_snapshots():
+        for isolate in otu.isolates:
+            for accession_key in isolate.accession_keys:
+                placements[accession_key].append(
+                    AccessionPlacement(
+                        otu_id=otu.id,
+                        otu_name=otu.name,
+                        otu_taxid=otu.taxid,
+                        isolate_id=isolate.id,
+                        isolate_name=isolate.name,
+                    )
+                )
+
+    cross_otu: dict[str, list[AccessionPlacement]] = {}
+    within_otu: dict[str, list[AccessionPlacement]] = {}
+
+    for accession_key, occurrences in placements.items():
+        if len(occurrences) < MIN_OCCURRENCES_FOR_DUPLICATE:
+            continue
+
+        otu_ids = {placement.otu_id for placement in occurrences}
+        if len(otu_ids) > 1:
+            cross_otu[accession_key] = occurrences
+        else:
+            within_otu[accession_key] = occurrences
+
+    return AccessionAuditReport(cross_otu=cross_otu, within_otu=within_otu)

--- a/ref_builder/cli/main.py
+++ b/ref_builder/cli/main.py
@@ -14,6 +14,7 @@ from ref_builder.cli.options import (
     path_option,
 )
 from ref_builder.cli.otu import otu
+from ref_builder.cli.validate_cmd import validate
 from ref_builder.console import console
 from ref_builder.logs import configure_logger
 from ref_builder.ncbi.client import NCBIClient
@@ -96,6 +97,7 @@ entry.add_command(build)
 entry.add_command(otu)
 entry.add_command(isolate)
 entry.add_command(event)
+entry.add_command(validate)
 
 # Only register dev commands in development (when tests directory exists)
 with suppress(ModuleNotFoundError):

--- a/ref_builder/cli/validate_cmd.py
+++ b/ref_builder/cli/validate_cmd.py
@@ -1,0 +1,77 @@
+"""``ref-builder validate`` — retroactive integrity checks for a repository."""
+
+import sys
+from pathlib import Path
+
+import click
+from rich.table import Table
+
+from ref_builder.audit import audit_accessions
+from ref_builder.cli.options import path_option
+from ref_builder.console import console
+from ref_builder.repo import Repo
+
+
+@click.group(name="validate")
+def validate() -> None:
+    """Run integrity checks against an existing repository."""
+
+
+@validate.command(name="accessions")
+@path_option
+def validate_accessions(path: Path) -> None:
+    """Report duplicate accessions across and within OTUs.
+
+    Exits non-zero when duplicates are found so the command can gate CI.
+    """
+    repo = Repo(path)
+
+    report = audit_accessions(repo)
+
+    if not report.has_findings:
+        console.print("[green]No duplicate accessions found.[/green]")
+        return
+
+    if report.cross_otu:
+        table = Table(
+            title="Cross-OTU duplicate accessions",
+            title_style="bold red",
+            show_lines=True,
+        )
+        table.add_column("Accession key")
+        table.add_column("OTU (taxid)")
+        table.add_column("Isolate")
+
+        for accession_key in sorted(report.cross_otu):
+            placements = report.cross_otu[accession_key]
+            for index, placement in enumerate(placements):
+                table.add_row(
+                    accession_key if index == 0 else "",
+                    f"{placement.otu_name} ({placement.otu_taxid})",
+                    f"{placement.isolate_name or 'Unnamed'} [{placement.isolate_id}]",
+                )
+
+        console.print(table)
+
+    if report.within_otu:
+        table = Table(
+            title="Within-OTU duplicate accessions",
+            title_style="bold red",
+            show_lines=True,
+        )
+        table.add_column("Accession key")
+        table.add_column("OTU (taxid)")
+        table.add_column("Isolate")
+
+        for accession_key in sorted(report.within_otu):
+            placements = report.within_otu[accession_key]
+            for index, placement in enumerate(placements):
+                table.add_row(
+                    accession_key if index == 0 else "",
+                    f"{placement.otu_name} ({placement.otu_taxid})",
+                    f"{placement.isolate_name or 'Unnamed'} [{placement.isolate_id}]",
+                )
+
+        console.print(table)
+
+    sys.exit(1)

--- a/ref_builder/errors.py
+++ b/ref_builder/errors.py
@@ -58,3 +58,19 @@ class PlanCreationError(ValueError):
 
 class PlanValidationError(ValueError):
     """Raised when an isolate does not pass plan validation."""
+
+
+class DuplicateAccessionError(Exception):
+    """Raised when an accession key is already owned by another OTU in the repo."""
+
+    def __init__(self, conflicts: dict[UUID, set[str]]):
+        self.conflicts = conflicts
+
+        parts = [
+            f"{', '.join(sorted(keys))} in OTU {otu_id}"
+            for otu_id, keys in conflicts.items()
+        ]
+
+        super().__init__(
+            "Accession(s) already exist in other OTUs: " + "; ".join(parts),
+        )

--- a/ref_builder/index.py
+++ b/ref_builder/index.py
@@ -143,6 +143,15 @@ class Index:
             """,
         )
 
+        self.con.execute(
+            """
+            CREATE TABLE IF NOT EXISTS sequence_keys (
+                accession_key TEXT,
+                otu_id TEXT
+            );
+            """,
+        )
+
         for table, column in [
             ("events", "otu_id"),
             ("isolates", "id"),
@@ -154,6 +163,8 @@ class Index:
             ("otu_updates", "otu_id"),
             ("otu_taxids", "otu_id"),
             ("otu_taxids", "taxid"),
+            ("sequence_keys", "accession_key"),
+            ("sequence_keys", "otu_id"),
         ]:
             self.con.execute(
                 f"""
@@ -169,6 +180,23 @@ class Index:
         return {
             row[0] for row in self.con.execute('SELECT id AS "id [uuid]" FROM otus')
         }
+
+    @property
+    def needs_rebuild(self) -> bool:
+        """True if the index has OTUs but is missing populated derived tables.
+
+        Used to migrate older indexes that pre-date the ``sequence_keys`` table.
+        """
+        has_otus = self.con.execute("SELECT 1 FROM otus LIMIT 1").fetchone() is not None
+        if not has_otus:
+            return False
+
+        has_sequence_keys = (
+            self.con.execute("SELECT 1 FROM sequence_keys LIMIT 1").fetchone()
+            is not None
+        )
+
+        return not has_sequence_keys
 
     def add_event_id(
         self,
@@ -282,6 +310,32 @@ class Index:
 
         return None
 
+    def get_otu_id_by_accession_key(self, accession_key: str) -> UUID | None:
+        """Get the OTU ID that currently owns a given accession key.
+
+        Returns ``None`` if no OTU contains a sequence with this accession key.
+        If the repo is corrupt and the key is shared, an arbitrary owner is returned.
+        """
+        cursor = self.con.execute(
+            'SELECT otu_id AS "otu_id [uuid]" FROM sequence_keys '
+            "WHERE accession_key = ? LIMIT 1",
+            (accession_key,),
+        )
+
+        if result := cursor.fetchone():
+            return result[0]
+
+        return None
+
+    def iter_accession_keys(self) -> Iterator[tuple[str, UUID]]:
+        """Iterate over all (accession_key, otu_id) pairs in the index."""
+        cursor = self.con.execute(
+            'SELECT accession_key, otu_id AS "otu_id [uuid]" FROM sequence_keys',
+        )
+
+        for row in cursor:
+            yield row[0], row[1]
+
     def delete_otu(self, otu_id: UUID) -> None:
         """Remove an OTU from the index.
 
@@ -306,6 +360,11 @@ class Index:
 
         self.con.execute(
             "DELETE FROM otu_taxids WHERE otu_id = ?",
+            (otu_id,),
+        )
+
+        self.con.execute(
+            "DELETE FROM sequence_keys WHERE otu_id = ?",
             (otu_id,),
         )
 
@@ -525,6 +584,21 @@ class Index:
         self.con.executemany(
             "INSERT INTO otu_taxids (otu_id, taxid) VALUES (?, ?)",
             [(otu.id, taxon.id) for taxon in otu.lineage.taxa],
+        )
+
+        # Delete and re-insert accession keys for this OTU
+        self.con.execute(
+            "DELETE FROM sequence_keys WHERE otu_id = ?",
+            (otu.id,),
+        )
+
+        self.con.executemany(
+            "INSERT INTO sequence_keys (accession_key, otu_id) VALUES (?, ?)",
+            [
+                (sequence.accession.key, otu.id)
+                for isolate in otu.isolates
+                for sequence in isolate.sequences
+            ],
         )
 
         self.con.commit()

--- a/ref_builder/models/otu.py
+++ b/ref_builder/models/otu.py
@@ -70,12 +70,45 @@ class OTU(BaseModel):
     """The plan for the OTU."""
 
     @model_validator(mode="after")
+    def check_no_duplicate_accessions(self) -> "OTU":
+        """Ensure no accession key appears in more than one isolate."""
+        seen: dict[str, list[UUID]] = {}
+
+        for isolate in self.isolates:
+            for accession in isolate.accessions:
+                seen.setdefault(accession, []).append(isolate.id)
+
+        duplicates = {
+            accession: isolate_ids
+            for accession, isolate_ids in seen.items()
+            if len(isolate_ids) > 1
+        }
+
+        if duplicates:
+            raise PydanticCustomError(
+                "duplicate_accession_within_otu",
+                "Accession(s) appear in multiple isolates: {duplicates}",
+                {
+                    "duplicates": {
+                        accession: sorted(str(i) for i in isolate_ids)
+                        for accession, isolate_ids in duplicates.items()
+                    },
+                },
+            )
+
+        return self
+
+    @model_validator(mode="after")
     def _rebuild_lookups_after_validation(self) -> "OTU":
         """Rebuild lookup dictionaries after model validation."""
         return self.rebuild_lookups()
 
     def rebuild_lookups(self) -> "OTU":
-        """Rebuild lookup dictionaries when isolates change."""
+        """Rebuild lookup dictionaries when isolates change.
+
+        Relies on ``check_no_duplicate_accessions`` having already enforced
+        per-accession uniqueness across isolates.
+        """
         self._isolates_by_accession = {
             accession: isolate
             for isolate in self.isolates

--- a/ref_builder/repo.py
+++ b/ref_builder/repo.py
@@ -300,9 +300,7 @@ class Repo:
                             if event.data.name is not None
                             else None
                         ),
-                        accession_keys=[
-                            s.accession.key for s in event.data.sequences
-                        ],
+                        accession_keys=[s.accession.key for s in event.data.sequences],
                     )
 
                 elif isinstance(event, DeleteIsolate):
@@ -647,9 +645,7 @@ class Repo:
         """Get an OTU ID from an isolate ID that belongs to it."""
         return self._index.get_id_by_isolate_id(isolate_id)
 
-    def get_otu_id_by_accession_key(
-        self, accession_key: str
-    ) -> uuid.UUID | None:
+    def get_otu_id_by_accession_key(self, accession_key: str) -> uuid.UUID | None:
         """Get the OTU ID that currently owns an accession key.
 
         Returns ``None`` if no OTU contains a sequence with this accession key.

--- a/ref_builder/repo.py
+++ b/ref_builder/repo.py
@@ -5,7 +5,6 @@ This is a work in progress.
 
 TODO: Check if excluded accessions exist in the repo.
 TODO: Check for accessions filed in wrong isolates.
-TODO: Check for accession conflicts.
 
 """
 
@@ -17,11 +16,16 @@ from collections import defaultdict
 from collections.abc import Collection, Generator, Iterator
 from contextlib import contextmanager
 from pathlib import Path
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from ref_builder.audit import OTUAuditSnapshot
 
 import arrow
 from structlog import get_logger
 
 from ref_builder.errors import (
+    DuplicateAccessionError,
     OTUDeletedError,
 )
 from ref_builder.events.base import (
@@ -99,8 +103,9 @@ class Repo:
         self._lock = Lock(self.path)
         """A lock for the repository."""
 
-        # Populate the index if it is empty.
-        if not self._index.otu_ids:
+        # Populate the index if it is empty, or migrate it if it lacks
+        # tables/columns added after the index was first built.
+        if not self._index.otu_ids or self._index.needs_rebuild:
             self.rebuild_index()
 
     @classmethod
@@ -248,6 +253,92 @@ class Repo:
             except OTUDeletedError:
                 continue
 
+    def iter_otu_audit_snapshots(
+        self,
+    ) -> Iterator["OTUAuditSnapshot"]:
+        """Yield per-OTU audit snapshots by walking events directly.
+
+        Bypasses Pydantic OTU validation so already-corrupt repos
+        (e.g. ones containing within-OTU duplicate accessions) can still
+        be inspected by audit tooling.
+        """
+        from ref_builder.audit import IsolateAuditSnapshot, OTUAuditSnapshot
+
+        event_ids_by_otu: dict[uuid.UUID, list[int]] = defaultdict(list)
+
+        for event in self._event_store.iter_events():
+            if hasattr(event.query, "otu_id"):
+                event_ids_by_otu[event.query.otu_id].append(event.id)
+
+        for otu_id, event_ids in event_ids_by_otu.items():
+            events = [self._event_store.read_event(eid) for eid in event_ids]
+            if not events:
+                continue
+
+            first_event = events[0]
+            if not isinstance(first_event, CreateOTU):
+                continue
+
+            taxid = first_event.data.lineage.taxa[0].id
+            name = first_event.data.lineage.taxa[0].name
+
+            isolates: dict[uuid.UUID, IsolateAuditSnapshot] = {}
+
+            seed = first_event.data.isolate
+            isolates[seed.id] = IsolateAuditSnapshot(
+                id=seed.id,
+                name=str(seed.name) if seed.name is not None else None,
+                accession_keys=[s.accession.key for s in seed.sequences],
+            )
+
+            for event in events[1:]:
+                if isinstance(event, CreateIsolate):
+                    isolates[event.data.id] = IsolateAuditSnapshot(
+                        id=event.data.id,
+                        name=(
+                            str(event.data.name)
+                            if event.data.name is not None
+                            else None
+                        ),
+                        accession_keys=[
+                            s.accession.key for s in event.data.sequences
+                        ],
+                    )
+
+                elif isinstance(event, DeleteIsolate):
+                    isolates.pop(event.query.isolate_id, None)
+
+                elif isinstance(event, PromoteIsolate):
+                    isolate = isolates.get(event.query.isolate_id)
+                    if isolate is None:
+                        continue
+
+                    for old_accession, new_sequence in event.data.map.items():
+                        if old_accession.key in isolate.accession_keys:
+                            isolate.accession_keys.remove(old_accession.key)
+                        isolate.accession_keys.append(new_sequence.accession.key)
+
+                elif isinstance(event, UpdateSequence):
+                    old_key = event.query.accession.key
+                    new_key = event.data.sequence.accession.key
+                    if old_key == new_key:
+                        continue
+                    for isolate in isolates.values():
+                        if old_key in isolate.accession_keys:
+                            isolate.accession_keys.remove(old_key)
+                            isolate.accession_keys.append(new_key)
+                            break
+
+            if not isolates:
+                continue
+
+            yield OTUAuditSnapshot(
+                id=otu_id,
+                taxid=taxid,
+                name=name,
+                isolates=list(isolates.values()),
+            )
+
     def create_otu(
         self,
         isolate: CreateIsolateData,
@@ -266,6 +357,11 @@ class Repo:
 
                 msg = f"OTU {otu.id} already contains taxid {taxon.id} ({taxon.name})"
                 raise ValueError(msg)
+
+        self._check_accessions_unused(
+            None,
+            {sequence.accession.key for sequence in isolate.sequences},
+        )
 
         taxid = lineage.taxa[0].id
 
@@ -305,6 +401,11 @@ class Repo:
         :param sequences: list of SequenceData objects
         :return: the created isolate
         """
+        self._check_accessions_unused(
+            otu_id,
+            {sequence.accession.key for sequence in sequences},
+        )
+
         event = self._write_event(
             CreateIsolate,
             CreateIsolateData(
@@ -381,6 +482,14 @@ class Repo:
         if isolate is None:
             raise ValueError(f"Isolate does not exist: {isolate_id}")
 
+        existing_keys = otu.accessions
+        new_keys = {
+            new_sequence.accession.key
+            for new_sequence in accession_map.values()
+            if new_sequence.accession.key not in existing_keys
+        }
+        self._check_accessions_unused(otu_id, new_keys)
+
         self._write_event(
             PromoteIsolate,
             PromoteIsolateData(map=accession_map),
@@ -399,6 +508,9 @@ class Repo:
         where the old sequence is linked and deletes the old sequence. Does not
         exclude accessions since the accession key remains the same.
         """
+        if new_sequence.accession.key != old_accession.key:
+            self._check_accessions_unused(otu_id, {new_sequence.accession.key})
+
         self._write_event(
             UpdateSequence,
             UpdateSequenceData(sequence=new_sequence),
@@ -534,6 +646,40 @@ class Repo:
     def get_otu_id_by_isolate_id(self, isolate_id: uuid.UUID) -> uuid.UUID | None:
         """Get an OTU ID from an isolate ID that belongs to it."""
         return self._index.get_id_by_isolate_id(isolate_id)
+
+    def get_otu_id_by_accession_key(
+        self, accession_key: str
+    ) -> uuid.UUID | None:
+        """Get the OTU ID that currently owns an accession key.
+
+        Returns ``None`` if no OTU contains a sequence with this accession key.
+        """
+        return self._index.get_otu_id_by_accession_key(accession_key)
+
+    @property
+    def accession_keys(self) -> set[str]:
+        """All accession keys (unversioned) currently stored across every OTU."""
+        return {key for key, _ in self._index.iter_accession_keys()}
+
+    def _check_accessions_unused(
+        self,
+        otu_id: uuid.UUID | None,
+        accession_keys: Collection[str],
+    ) -> None:
+        """Raise ``DuplicateAccessionError`` if any key already lives in another OTU.
+
+        ``otu_id`` may be ``None`` (for new OTU creation), in which case any existing
+        owner is a conflict.
+        """
+        conflicts: dict[uuid.UUID, set[str]] = defaultdict(set)
+
+        for key in accession_keys:
+            existing_owner = self._index.get_otu_id_by_accession_key(key)
+            if existing_owner is not None and existing_owner != otu_id:
+                conflicts[existing_owner].add(key)
+
+        if conflicts:
+            raise DuplicateAccessionError(dict(conflicts))
 
     def get_otu(self, otu_id: uuid.UUID) -> OTU | None:
         """Get the OTU with the given ``otu_id``.

--- a/ref_builder/services/isolate.py
+++ b/ref_builder/services/isolate.py
@@ -71,10 +71,10 @@ class IsolateService(Service):
 
         log = log.bind(otu_id=str(otu.id), otu_name=otu.name)
 
-        # Filter out blocked accessions
+        # Filter out blocked accessions (per-OTU and anywhere else in the repo).
         eligible_accessions = filter_accessions(
             [r.accession for r in fetched_records],
-            otu.blocked_accessions,
+            otu.blocked_accessions | self._repo.accession_keys,
         )
 
         if not eligible_accessions:

--- a/ref_builder/services/otu.py
+++ b/ref_builder/services/otu.py
@@ -284,7 +284,11 @@ class OTUService(Service):
             refseq_only=True,
         )
 
-        fetch_set = {accession.key for accession in accessions} - otu.blocked_accessions
+        fetch_set = (
+            {accession.key for accession in accessions}
+            - otu.blocked_accessions
+            - self._repo.accession_keys
+        )
 
         if fetch_set:
             records = self.ncbi.fetch_genbank_records(fetch_set)
@@ -467,7 +471,11 @@ class OTUService(Service):
             sequence_max_length=get_segments_max_length(otu.plan.segments),
         )
 
-        fetch_set = {accession.key for accession in accessions} - otu.blocked_accessions
+        fetch_set = (
+            {accession.key for accession in accessions}
+            - otu.blocked_accessions
+            - self._repo.accession_keys
+        )
 
         if fetch_set:
             log.info("Adding new isolates from NCBI.")

--- a/ref_builder/services/repo.py
+++ b/ref_builder/services/repo.py
@@ -59,7 +59,10 @@ class RepoService(Service):
             )
         )
 
-        batch_fetch_index = _fetch_new_accessions(otu_iterator)
+        batch_fetch_index = _fetch_new_accessions(
+            otu_iterator,
+            repo_blocked_accessions=self._repo.accession_keys,
+        )
 
         if not batch_fetch_index:
             logger.info("OTUs are up to date.")
@@ -184,9 +187,19 @@ def _otu_is_cooled(
 def _fetch_new_accessions(
     otus: Iterable[OTU],
     ignore_cache: bool = False,
+    repo_blocked_accessions: set[str] | None = None,
 ) -> dict[int, set[str]]:
-    """Check OTU iterator for new accessions and return results indexed by taxid."""
+    """Check OTU iterator for new accessions and return results indexed by taxid.
+
+    ``repo_blocked_accessions`` is a snapshot of every accession key currently
+    stored in the repo. Subtracting it here prevents re-fetching accessions that
+    already live in a different OTU (e.g. after a taxonomic reclassification at
+    NCBI). The write-time guard in ``Repo`` catches anything missed by this filter.
+    """
     ncbi = NCBIClient(ignore_cache)
+
+    if repo_blocked_accessions is None:
+        repo_blocked_accessions = set()
 
     otu_counter = 0
 
@@ -209,9 +222,11 @@ def _fetch_new_accessions(
             sequence_max_length=get_segments_max_length(otu.plan.segments),
         )
 
-        accessions_to_fetch = {
-            accession.key for accession in accessions
-        } - otu.blocked_accessions
+        accessions_to_fetch = (
+            {accession.key for accession in accessions}
+            - otu.blocked_accessions
+            - repo_blocked_accessions
+        )
 
         if accessions_to_fetch:
             log.debug(

--- a/tests/cli/test_validate.py
+++ b/tests/cli/test_validate.py
@@ -1,0 +1,199 @@
+"""Tests for ``ref-builder validate accessions``."""
+
+from pathlib import Path
+from uuid import uuid4
+
+import pytest
+from click.testing import CliRunner
+
+import arrow
+
+from ref_builder.cli.validate_cmd import validate as validate_command_group
+from ref_builder.events.base import IsolateQuery
+from ref_builder.events.isolate import CreateIsolate, CreateIsolateData
+from ref_builder.models.accession import Accession
+from ref_builder.models.isolate import IsolateName, IsolateNameType
+from ref_builder.models.lineage import Lineage, Taxon, TaxonOtherNames
+from ref_builder.models.molecule import Molecule, MoleculeType, Strandedness, Topology
+from ref_builder.models.plan import Plan, Segment
+from ref_builder.models.sequence import Sequence
+from ref_builder.ncbi.models import NCBIRank
+from ref_builder.repo import Repo
+
+runner = CliRunner()
+
+SEGMENT_LENGTH = 15
+
+TMV_LINEAGE = Lineage(
+    taxa=[
+        Taxon(
+            id=3432891,
+            name="Tobamovirus tabaci",
+            parent=None,
+            rank=NCBIRank.SPECIES,
+            other_names=TaxonOtherNames(acronym=[], synonyms=[]),
+        )
+    ]
+)
+
+CMV_LINEAGE = Lineage(
+    taxa=[
+        Taxon(
+            id=12305,
+            name="Cucumovirus mosaiccucumeris",
+            parent=None,
+            rank=NCBIRank.SPECIES,
+            other_names=TaxonOtherNames(acronym=[], synonyms=[]),
+        )
+    ]
+)
+
+MOLECULE = Molecule(
+    strandedness=Strandedness.SINGLE,
+    type=MoleculeType.RNA,
+    topology=Topology.LINEAR,
+)
+
+
+def _plan(repo: Repo) -> Plan:
+    return Plan.new(
+        [
+            Segment.new(
+                length=SEGMENT_LENGTH,
+                length_tolerance=repo.settings.default_segment_length_tolerance,
+                name=None,
+            )
+        ]
+    )
+
+
+def _seed_isolate(plan: Plan, accession_key: str, taxid: int) -> CreateIsolateData:
+    return CreateIsolateData(
+        id=uuid4(),
+        name=IsolateName(IsolateNameType.ISOLATE, "Seed"),
+        taxid=taxid,
+        sequences=[
+            Sequence(
+                accession=Accession(key=accession_key, version=1),
+                definition="seed",
+                segment=plan.segments[0].id,
+                sequence="ACGTACGTACGTACG",
+            )
+        ],
+    )
+
+
+@pytest.fixture
+def clean_repo(empty_repo: Repo) -> Repo:
+    """A two-OTU repo with no duplicate accessions."""
+    plan = _plan(empty_repo)
+
+    with empty_repo.lock():
+        empty_repo.create_otu(
+            isolate=_seed_isolate(plan, "TM000001", taxid=3432891),
+            lineage=TMV_LINEAGE,
+            molecule=MOLECULE,
+            plan=plan,
+            promoted_accessions=set(),
+        )
+        empty_repo.create_otu(
+            isolate=_seed_isolate(plan, "AB000001", taxid=12305),
+            lineage=CMV_LINEAGE,
+            molecule=MOLECULE,
+            plan=plan,
+            promoted_accessions=set(),
+        )
+
+    return empty_repo
+
+
+def _raw_write_create_isolate(
+    repo: Repo,
+    otu_id,
+    accession_key: str,
+    plan: Plan,
+    taxid: int,
+    isolate_label: str,
+) -> None:
+    """Write a CreateIsolate event directly, bypassing all validation guards."""
+    event = CreateIsolate(
+        id=repo.last_id + 1,
+        data=CreateIsolateData(
+            id=uuid4(),
+            name=IsolateName(IsolateNameType.ISOLATE, isolate_label),
+            taxid=taxid,
+            sequences=[
+                Sequence(
+                    accession=Accession(key=accession_key, version=1),
+                    definition=isolate_label,
+                    segment=plan.segments[0].id,
+                    sequence="ACGTACGTACGTACG",
+                )
+            ],
+        ),
+        query=IsolateQuery(isolate_id=uuid4(), otu_id=otu_id),
+        timestamp=arrow.utcnow().naive,
+    )
+    written = repo._event_store.write_event(event)
+    repo._index.add_event_id(written.id, otu_id, written.timestamp)
+
+
+def _corrupt_repo_with_dupes(repo: Repo) -> None:
+    """Build a repo that contains both cross-OTU and within-OTU duplicate accessions.
+
+    Writes the conflicting events directly to the event store so the corruption
+    mimics what an already-broken on-disk reference (e.g. plant-viruses) looks like.
+    """
+    plan = _plan(repo)
+
+    with repo.lock():
+        otu_tmv = repo.create_otu(
+            isolate=_seed_isolate(plan, "TM000001", taxid=3432891),
+            lineage=TMV_LINEAGE,
+            molecule=MOLECULE,
+            plan=plan,
+            promoted_accessions=set(),
+        )
+        otu_cmv = repo.create_otu(
+            isolate=_seed_isolate(plan, "AB000001", taxid=12305),
+            lineage=CMV_LINEAGE,
+            molecule=MOLECULE,
+            plan=plan,
+            promoted_accessions=set(),
+        )
+
+        _raw_write_create_isolate(
+            repo, otu_cmv.id, "TM000001", plan, 12305, "DupeAcross"
+        )
+        # Distinct accession reused within TMV so the within-OTU report fires.
+        _raw_write_create_isolate(
+            repo, otu_tmv.id, "TN000001", plan, 3432891, "WithinA"
+        )
+        _raw_write_create_isolate(
+            repo, otu_tmv.id, "TN000001", plan, 3432891, "WithinB"
+        )
+
+
+class TestValidateAccessionsCommand:
+    def test_clean_repo_exits_zero(self, clean_repo: Repo):
+        """A repo with no duplicates exits 0 and reports cleanly."""
+        result = runner.invoke(
+            validate_command_group, ["accessions", "--path", str(clean_repo.path)]
+        )
+
+        assert result.exit_code == 0
+        assert "No duplicate accessions found" in result.output
+
+    def test_corrupt_repo_reports_and_exits_nonzero(self, tmp_path: Path):
+        """A repo containing both kinds of duplicate exits non-zero and reports both."""
+        repo = Repo.new("Generic Viruses", tmp_path / "corrupt_repo", "virus")
+        _corrupt_repo_with_dupes(repo)
+
+        result = runner.invoke(
+            validate_command_group, ["accessions", "--path", str(repo.path)]
+        )
+
+        assert result.exit_code == 1
+        assert "Cross-OTU duplicate accessions" in result.output
+        assert "Within-OTU duplicate accessions" in result.output
+        assert "TM000001" in result.output

--- a/tests/cli/test_validate.py
+++ b/tests/cli/test_validate.py
@@ -3,10 +3,9 @@
 from pathlib import Path
 from uuid import uuid4
 
+import arrow
 import pytest
 from click.testing import CliRunner
-
-import arrow
 
 from ref_builder.cli.validate_cmd import validate as validate_command_group
 from ref_builder.events.base import IsolateQuery

--- a/tests/models/test_otu.py
+++ b/tests/models/test_otu.py
@@ -213,3 +213,15 @@ class TestOTU:
         otu_data["isolates"][0]["taxid"] = 3432891
 
         assert OTU.model_validate(otu_data)
+
+    def test_duplicate_accession_across_isolates(self):
+        """Validation must fail if two isolates share an accession key."""
+        otu_data = self.otu.model_dump()
+        shared_accession = otu_data["isolates"][0]["sequences"][0]["accession"]
+        otu_data["isolates"][1]["sequences"][0]["accession"] = shared_accession
+
+        with pytest.raises(
+            ValidationError,
+            match="Accession\\(s\\) appear in multiple isolates",
+        ):
+            OTU.model_validate(otu_data)

--- a/tests/test_repo.py
+++ b/tests/test_repo.py
@@ -1290,9 +1290,7 @@ class TestDuplicateAccessions:
         assert existing_otu.id in excinfo.value.conflicts
         assert "TM000001" in excinfo.value.conflicts[existing_otu.id]
 
-    def test_create_otu_rejects_accession_in_other_otu(
-        self, initialized_repo: Repo
-    ):
+    def test_create_otu_rejects_accession_in_other_otu(self, initialized_repo: Repo):
         """Creating a new OTU whose seed isolate's accession already lives in
         another OTU must raise DuplicateAccessionError.
         """
@@ -1347,12 +1345,8 @@ class TestDuplicateAccessions:
         """The new repo-wide lookup returns the OTU that owns a given key."""
         otu = initialized_repo.get_otu_by_taxid(3432891)
 
-        assert (
-            initialized_repo.get_otu_id_by_accession_key("TM000001") == otu.id
-        )
-        assert (
-            initialized_repo.get_otu_id_by_accession_key("DOES_NOT_EXIST") is None
-        )
+        assert initialized_repo.get_otu_id_by_accession_key("TM000001") == otu.id
+        assert initialized_repo.get_otu_id_by_accession_key("DOES_NOT_EXIST") is None
 
     def test_accession_keys_property(self, initialized_repo: Repo):
         """``Repo.accession_keys`` covers every accession across all OTUs."""

--- a/tests/test_repo.py
+++ b/tests/test_repo.py
@@ -5,6 +5,7 @@ import orjson
 import pytest
 from structlog.testing import capture_logs
 
+from ref_builder.errors import DuplicateAccessionError
 from ref_builder.events.isolate import CreateIsolateData
 from ref_builder.models.accession import Accession
 from ref_builder.models.isolate import Isolate, IsolateName, IsolateNameType
@@ -40,6 +41,25 @@ TMV_LINEAGE = Lineage(
             parent=3432891,
             rank=NCBIRank.NO_RANK,
             other_names=TaxonOtherNames(acronym=[], synonyms=[]),
+        ),
+    ]
+)
+
+CMV_LINEAGE = Lineage(
+    taxa=[
+        Taxon(
+            id=12305,
+            name="Cucumovirus mosaiccucumeris",
+            parent=None,
+            rank=NCBIRank.SPECIES,
+            other_names=TaxonOtherNames(acronym=[], synonyms=[]),
+        ),
+        Taxon(
+            id=12306,
+            name="Cucumber mosaic virus",
+            parent=12305,
+            rank=NCBIRank.NO_RANK,
+            other_names=TaxonOtherNames(acronym=["CMV"], synonyms=[]),
         ),
     ]
 )
@@ -1195,3 +1215,161 @@ class TestMalformedEvent:
             ),
         ):
             initialized_repo.get_otu_by_taxid(3432891)
+
+
+def _make_cmv_isolate_data(plan: Plan, accession_key: str) -> CreateIsolateData:
+    return CreateIsolateData(
+        id=uuid4(),
+        name=IsolateName(IsolateNameType.ISOLATE, "Z"),
+        taxid=12306,
+        sequences=[
+            Sequence(
+                accession=Accession(key=accession_key, version=1),
+                definition="CMV",
+                segment=plan.segments[0].id,
+                sequence="ACGTACGTACGTACG",
+            )
+        ],
+    )
+
+
+def _make_plan(repo: Repo) -> Plan:
+    return Plan.new(
+        [
+            Segment.new(
+                length=SEGMENT_LENGTH,
+                length_tolerance=repo.settings.default_segment_length_tolerance,
+                name=None,
+            )
+        ]
+    )
+
+
+class TestDuplicateAccessions:
+    """Cross-OTU and within-OTU accession-conflict protection (issue #309)."""
+
+    def test_create_isolate_rejects_accession_in_other_otu(
+        self, initialized_repo: Repo
+    ):
+        """Creating an isolate whose accession already lives in another OTU
+        must raise DuplicateAccessionError.
+        """
+        existing_otu = initialized_repo.get_otu_by_taxid(3432891)
+        plan = _make_plan(initialized_repo)
+
+        with initialized_repo.lock():
+            other_otu = initialized_repo.create_otu(
+                isolate=_make_cmv_isolate_data(plan, "AB000001"),
+                lineage=CMV_LINEAGE,
+                molecule=Molecule(
+                    strandedness=Strandedness.SINGLE,
+                    type=MoleculeType.RNA,
+                    topology=Topology.LINEAR,
+                ),
+                plan=plan,
+                promoted_accessions=set(),
+            )
+            assert other_otu is not None
+
+            with pytest.raises(DuplicateAccessionError) as excinfo:
+                initialized_repo.create_isolate(
+                    other_otu.id,
+                    isolate_id=uuid4(),
+                    name=IsolateName(IsolateNameType.ISOLATE, "Y"),
+                    taxid=12306,
+                    sequences=[
+                        Sequence(
+                            accession=Accession(key="TM000001", version=1),
+                            definition="TMV",
+                            segment=plan.segments[0].id,
+                            sequence="ACGTACGTACGTACG",
+                        )
+                    ],
+                )
+
+        assert existing_otu.id in excinfo.value.conflicts
+        assert "TM000001" in excinfo.value.conflicts[existing_otu.id]
+
+    def test_create_otu_rejects_accession_in_other_otu(
+        self, initialized_repo: Repo
+    ):
+        """Creating a new OTU whose seed isolate's accession already lives in
+        another OTU must raise DuplicateAccessionError.
+        """
+        plan = _make_plan(initialized_repo)
+
+        with initialized_repo.lock(), pytest.raises(DuplicateAccessionError):
+            initialized_repo.create_otu(
+                isolate=_make_cmv_isolate_data(plan, "TM000001"),
+                lineage=CMV_LINEAGE,
+                molecule=Molecule(
+                    strandedness=Strandedness.SINGLE,
+                    type=MoleculeType.RNA,
+                    topology=Topology.LINEAR,
+                ),
+                plan=plan,
+                promoted_accessions=set(),
+            )
+
+    def test_update_sequence_rejects_accession_in_other_otu(
+        self, initialized_repo: Repo
+    ):
+        """update_sequence must reject a new key already owned elsewhere."""
+        plan = _make_plan(initialized_repo)
+
+        with initialized_repo.lock():
+            other_otu = initialized_repo.create_otu(
+                isolate=_make_cmv_isolate_data(plan, "AB000001"),
+                lineage=CMV_LINEAGE,
+                molecule=Molecule(
+                    strandedness=Strandedness.SINGLE,
+                    type=MoleculeType.RNA,
+                    topology=Topology.LINEAR,
+                ),
+                plan=plan,
+                promoted_accessions=set(),
+            )
+            assert other_otu is not None
+
+            with pytest.raises(DuplicateAccessionError):
+                initialized_repo.update_sequence(
+                    other_otu.id,
+                    old_accession=Accession(key="AB000001", version=1),
+                    new_sequence=Sequence(
+                        accession=Accession(key="TM000001", version=2),
+                        definition="reassigned",
+                        segment=plan.segments[0].id,
+                        sequence="ACGTACGTACGTACG",
+                    ),
+                )
+
+    def test_get_otu_id_by_accession_key(self, initialized_repo: Repo):
+        """The new repo-wide lookup returns the OTU that owns a given key."""
+        otu = initialized_repo.get_otu_by_taxid(3432891)
+
+        assert (
+            initialized_repo.get_otu_id_by_accession_key("TM000001") == otu.id
+        )
+        assert (
+            initialized_repo.get_otu_id_by_accession_key("DOES_NOT_EXIST") is None
+        )
+
+    def test_accession_keys_property(self, initialized_repo: Repo):
+        """``Repo.accession_keys`` covers every accession across all OTUs."""
+        plan = _make_plan(initialized_repo)
+
+        with initialized_repo.lock():
+            other_otu = initialized_repo.create_otu(
+                isolate=_make_cmv_isolate_data(plan, "AB000001"),
+                lineage=CMV_LINEAGE,
+                molecule=Molecule(
+                    strandedness=Strandedness.SINGLE,
+                    type=MoleculeType.RNA,
+                    topology=Topology.LINEAR,
+                ),
+                plan=plan,
+                promoted_accessions=set(),
+            )
+            assert other_otu is not None
+
+        assert initialized_repo.accession_keys == {"TM000001", "AB000001"}


### PR DESCRIPTION
## Summary

- Adds a `sequence_keys` table to the SQLite index tracking which OTU owns each accession key, enabling O(1) cross-OTU duplicate checks at write time
- Raises `DuplicateAccessionError` in `Repo.create_otu`, `create_isolate`, `promote_isolate`, and `update_sequence` when an accession key is already owned by a different OTU; also adds an `OTU` model validator that rejects within-OTU duplicates at construction time
- Introduces a `ref-builder validate accessions` CLI command (backed by a new `audit.py` module) that walks raw events to surface existing corruption in repos that pre-date these guards, and exits non-zero when duplicates are found so it can gate CI

## Test plan

- [ ] `pytest tests/models/test_otu.py` — new `test_duplicate_accession_across_isolates` test passes
- [ ] `pytest tests/test_repo.py::TestDuplicateAccessions` — all five new cross-OTU / accession-key tests pass
- [ ] `pytest tests/cli/test_validate.py` — clean-repo exits 0, corrupt-repo exits 1 and reports both kinds of duplicates
- [ ] Run `ref-builder validate accessions --path <existing-repo>` against a real reference to confirm no false positives
- [ ] Confirm older repos are migrated transparently on first load (index rebuild fills the new `sequence_keys` table)