### PR TITLE
chore: replace pyright with ty and fix type errors surfaced by the switch

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,12 +31,12 @@ ref-builder = "ref_builder.cli.main:entry"
 [dependency-groups]
 dev = [
   "polyfactory>=2.22.2",
-  "pyright>=1.1.405",
   "pytest>=8.4.2",
   "pytest-mock>=3.15.1",
   "pytest-structlog>=1.2",
   "ruff>=0.13.2",
   "syrupy>=4.9.1",
+  "ty>=0.0.42",
 ]
 
 [tool.ruff.lint]

--- a/ref_builder/build/virtool.py
+++ b/ref_builder/build/virtool.py
@@ -143,9 +143,7 @@ class ProductionSequence(ProductionResource):
         segment = otu_plan.get_segment_by_id(validated_sequence.segment)
 
         if segment is None:
-            raise ValueError(
-                f"Segment not found in plan: {validated_sequence.segment}"
-            )
+            raise ValueError(f"Segment not found in plan: {validated_sequence.segment}")
 
         return ProductionSequence(
             id=str(validated_sequence.accession),

--- a/ref_builder/build/virtool.py
+++ b/ref_builder/build/virtool.py
@@ -142,6 +142,11 @@ class ProductionSequence(ProductionResource):
     ) -> "ProductionSequence":
         segment = otu_plan.get_segment_by_id(validated_sequence.segment)
 
+        if segment is None:
+            raise ValueError(
+                f"Segment not found in plan: {validated_sequence.segment}"
+            )
+
         return ProductionSequence(
             id=str(validated_sequence.accession),
             accession=str(validated_sequence.accession),

--- a/ref_builder/cli/dev.py
+++ b/ref_builder/cli/dev.py
@@ -133,9 +133,23 @@ def refresh() -> None:
         generated_count += 1
 
     # Generate type stub
+    stub_path = _generate_stub()
+    click.echo(f"  Wrote {stub_path}")
+
+    click.echo(f"\n✓ Generated {generated_count} OTUs in {output_path}")
+
+
+def _generate_stub() -> Path:
+    """Generate the ``models.pyi`` type stub from the OTU manifest.
+
+    Emits static declarations for ``OTUSpec``/``OTUHandle`` and the dynamic
+    ``OTURegistry``, whose ``@property`` OTU handles mirror the manifest entries.
+    Returns the path to the written stub.
+    """
     stub_path = Path("tests/fixtures/ncbi/models.pyi")
     stub_lines = [
         "from dataclasses import dataclass",
+        "from pathlib import Path",
         "",
         "",
         "class OTUSpec:",
@@ -164,6 +178,9 @@ def refresh() -> None:
         "",
         "",
         "class OTURegistry:",
+        "    def __init__(self, manifest: type, data_dir: Path) -> None: ...",
+        "    def validate(self) -> None: ...",
+        "",
     ]
 
     for attr_name in dir(OTUManifest):
@@ -176,6 +193,16 @@ def refresh() -> None:
             stub_lines.append("")
 
     stub_path.write_text("\n".join(stub_lines))
-    click.echo(f"  Wrote {stub_path}")
 
-    click.echo(f"\n✓ Generated {generated_count} OTUs in {output_path}")
+    return stub_path
+
+
+@dev.command(name="stub")
+def stub() -> None:
+    """Regenerate the mock OTU registry type stub from the manifest.
+
+    Unlike ``refresh``, this does not fetch from NCBI; it only rewrites
+    ``tests/fixtures/ncbi/models.pyi`` from the current manifest.
+    """
+    stub_path = _generate_stub()
+    click.echo(f"✓ Wrote {stub_path}")

--- a/ref_builder/cli/isolate.py
+++ b/ref_builder/cli/isolate.py
@@ -72,5 +72,15 @@ def isolate_get(repo: Repo, isolate_id: UUID) -> None:
         sys.exit(1)
 
     otu_id = repo.get_otu_id_by_isolate_id(isolate_id)
+
+    if otu_id is None:
+        click.echo("OTU could not be found.", err=True)
+        sys.exit(1)
+
     otu_ = repo.get_otu(otu_id)
+
+    if otu_ is None:
+        click.echo("OTU could not be found.", err=True)
+        sys.exit(1)
+
     print_isolate(isolate_, otu_.plan)

--- a/ref_builder/cli/otu.py
+++ b/ref_builder/cli/otu.py
@@ -171,7 +171,7 @@ def otu_update(
     services.otu.update(otu_.id)
 
 
-@otu.command(name="exclude-accessions")  # type: ignore
+@otu.command(name="exclude-accessions")
 @click.argument("IDENTIFIER", type=str)
 @click.argument(
     "accessions_",
@@ -203,7 +203,7 @@ def otu_exclude_accessions(
     services.otu.exclude_accessions(otu_.id, set(accessions_))
 
 
-@otu.command(name="allow-accessions")  # type: ignore
+@otu.command(name="allow-accessions")
 @click.argument("IDENTIFIER", type=str)
 @click.argument(
     "accessions_",

--- a/ref_builder/console.py
+++ b/ref_builder/console.py
@@ -273,10 +273,12 @@ def _print_isolate(
         isolate.sequences,
         key=lambda s: index_by_segment_id[s.segment],
     ):
+        segment = plan.get_segment_by_id(sequence.segment)
+
         isolate_table.add_row(
             _render_nucleotide_link(str(sequence.accession)),
             str(len(sequence.sequence)),
-            str(plan.get_segment_by_id(sequence.segment).name or "Unnamed"),
+            str((segment.name if segment is not None else None) or "Unnamed"),
             sequence.definition,
         )
 

--- a/ref_builder/logs.py
+++ b/ref_builder/logs.py
@@ -2,6 +2,7 @@ import logging
 import os
 
 import structlog
+from structlog.typing import Processor
 
 NO_COLOR = os.environ.get("NO_COLOR") is not None
 
@@ -15,7 +16,7 @@ def configure_logger(verbosity: int, no_color: bool = False) -> None:
     # Disable faker logging.
     logging.getLogger("faker").setLevel(logging.ERROR)
 
-    processors = [
+    processors: list[Processor] = [
         structlog.processors.add_log_level,
         structlog.processors.TimeStamper(fmt="iso"),
     ]

--- a/ref_builder/models/otu.py
+++ b/ref_builder/models/otu.py
@@ -70,6 +70,10 @@ class OTU(BaseModel):
     """The plan for the OTU."""
 
     @model_validator(mode="after")
+    def _rebuild_lookups_after_validation(self) -> "OTU":
+        """Rebuild lookup dictionaries after model validation."""
+        return self.rebuild_lookups()
+
     def rebuild_lookups(self) -> "OTU":
         """Rebuild lookup dictionaries when isolates change."""
         self._isolates_by_accession = {

--- a/ref_builder/ncbi/client.py
+++ b/ref_builder/ncbi/client.py
@@ -2,7 +2,7 @@
 
 import datetime
 import os
-from collections.abc import Collection
+from collections.abc import Collection, Iterator
 from contextlib import contextmanager, suppress
 from enum import StrEnum
 from http import HTTPStatus
@@ -590,7 +590,7 @@ class NCBIClient:
 
 
 @contextmanager
-def log_http_error() -> None:
+def log_http_error() -> Iterator[None]:
     """Log detailed HTTPError info for debugging before throwing the HTTPError."""
     try:
         yield

--- a/ref_builder/ncbi/client.py
+++ b/ref_builder/ncbi/client.py
@@ -164,7 +164,7 @@ class NCBIClient:
                     key = accession
 
             if key not in cached_keys:
-                accessions_to_fetch.append(accession)
+                accessions_to_fetch.append(str(accession))
 
         if accessions_to_fetch:
             total_to_fetch = len(accessions_to_fetch)

--- a/ref_builder/ncbi/client.py
+++ b/ref_builder/ncbi/client.py
@@ -55,6 +55,8 @@ class NCBIClientProtocol(Protocol):
 
     def fetch_descendant_taxids(self, species_taxid: int) -> list[int]: ...
 
+    def fetch_lineage(self, taxid: int) -> Lineage: ...
+
     @staticmethod
     def fetch_accessions_by_taxid(
         taxid: int,

--- a/ref_builder/ncbi/client.py
+++ b/ref_builder/ncbi/client.py
@@ -23,11 +23,14 @@ from ref_builder.ncbi.models import (
     NCBITaxonomy,
 )
 
+# Biopython ships py.typed but declares these Entrez config globals as bare
+# `None`, so ty infers their type as `None` and rejects str assignment. This is
+# an upstream typing bug, not unsafe code.
 if email := os.environ.get("NCBI_EMAIL"):
-    Entrez.email = email
+    Entrez.email = email  # ty: ignore[invalid-assignment]
 
 if api_key := os.environ.get("NCBI_API_KEY"):
-    Entrez.api_key = os.environ.get("NCBI_API_KEY")
+    Entrez.api_key = api_key  # ty: ignore[invalid-assignment]
 
 logger = get_logger("ncbi")
 

--- a/ref_builder/ncbi/models.py
+++ b/ref_builder/ncbi/models.py
@@ -152,7 +152,9 @@ class NCBIGenbank(BaseModel):
 
     @field_validator("source", mode="before")
     @classmethod
-    def convert_source(cls, raw: NCBISource | dict | list[dict[str, Any]]) -> NCBISource:
+    def convert_source(
+        cls, raw: NCBISource | dict | list[dict[str, Any]]
+    ) -> NCBISource:
         """If the source field isn't a ``NCBISource`` object, convert it."""
         # Already validated NCBISource instance (no conversion needed).
         if isinstance(raw, NCBISource):

--- a/ref_builder/ncbi/models.py
+++ b/ref_builder/ncbi/models.py
@@ -152,7 +152,7 @@ class NCBIGenbank(BaseModel):
 
     @field_validator("source", mode="before")
     @classmethod
-    def convert_source(cls, raw: NCBISource | dict | list[dict[str:Any]]) -> NCBISource:
+    def convert_source(cls, raw: NCBISource | dict | list[dict[str, Any]]) -> NCBISource:
         """If the source field isn't a ``NCBISource`` object, convert it."""
         # Already validated NCBISource instance (no conversion needed).
         if isinstance(raw, NCBISource):

--- a/ref_builder/ncbi/models.py
+++ b/ref_builder/ncbi/models.py
@@ -135,7 +135,8 @@ class NCBIGenbank(BaseModel):
     source: Annotated[NCBISource, Field(validation_alias="GBSeq_feature-table")]
     comment: Annotated[str, Field(validation_alias="GBSeq_comment")] = ""
 
-    @computed_field()
+    @computed_field
+    @property
     def refseq(self) -> bool:
         """Whether this is a RefSeq record.
 
@@ -232,6 +233,7 @@ class NCBITaxonomy(BaseModel):
         return v
 
     @computed_field
+    @property
     def species(self) -> NCBILineage:
         """Return the species level taxon in the lineage."""
         if self.rank is NCBIRank.SPECIES:

--- a/ref_builder/plan.py
+++ b/ref_builder/plan.py
@@ -36,12 +36,14 @@ def extract_segment_name_from_record_with_plan(
         return segment_name
 
     if not plan.monopartite:
-        try:
-            plan_keys_and_prefixes = {
-                segment.name.key: segment.name.prefix for segment in plan.segments
-            }
-        except AttributeError:
+        if any(segment.name is None for segment in plan.segments):
             raise ValueError("Multipartite plan contains unnamed segments")
+
+        plan_keys_and_prefixes = {
+            segment.name.key: segment.name.prefix
+            for segment in plan.segments
+            if segment.name is not None
+        }
 
         # Handle no prefix.
         with suppress(KeyError):

--- a/ref_builder/promote.py
+++ b/ref_builder/promote.py
@@ -140,7 +140,12 @@ def promote_otu_from_records(
             )
             continue
 
-        otu = repo.get_otu(otu.id)
+        refreshed_otu = repo.get_otu(otu.id)
+
+        if refreshed_otu is None:
+            raise ValueError(f"OTU does not exist: {otu.id}")
+
+        otu = refreshed_otu
 
     if promoted_accessions:
         log.info(

--- a/ref_builder/repo.py
+++ b/ref_builder/repo.py
@@ -577,7 +577,7 @@ class Repo:
 
         return otu
 
-    def iter_otu_events(self, otu_id: uuid.UUID) -> Generator[ApplicableEvent]:
+    def iter_otu_events(self, otu_id: uuid.UUID) -> Generator[Event]:
         """Iterate through event log."""
         event_index_item = self._index.get_event_ids_by_otu_id(otu_id)
 

--- a/ref_builder/repo.py
+++ b/ref_builder/repo.py
@@ -330,7 +330,12 @@ class Repo:
         if otu is None:
             raise ValueError(f"OTU does not exist: {otu_id}")
 
-        return otu.get_isolate(isolate_id)
+        isolate = otu.get_isolate(isolate_id)
+
+        if isolate is None:
+            raise ValueError(f"Isolate does not exist: {isolate_id}")
+
+        return isolate
 
     def delete_isolate(
         self,

--- a/ref_builder/repo.py
+++ b/ref_builder/repo.py
@@ -260,6 +260,10 @@ class Repo:
         for taxon in lineage.taxa:
             if (otu_id := self.get_otu_id_by_taxid(taxon.id)) is not None:
                 otu = self.get_otu(otu_id)
+
+                if otu is None:
+                    raise ValueError(f"OTU does not exist: {otu_id}")
+
                 msg = f"OTU {otu.id} already contains taxid {taxon.id} ({taxon.name})"
                 raise ValueError(msg)
 
@@ -321,7 +325,12 @@ class Repo:
             sequence_count=len(sequences),
         )
 
-        return self.get_otu(otu_id).get_isolate(isolate_id)
+        otu = self.get_otu(otu_id)
+
+        if otu is None:
+            raise ValueError(f"OTU does not exist: {otu_id}")
+
+        return otu.get_isolate(isolate_id)
 
     def delete_isolate(
         self,
@@ -399,7 +408,12 @@ class Repo:
             OTUQuery(otu_id=otu_id),
         )
 
-        return self.get_otu(otu_id).plan
+        otu = self.get_otu(otu_id)
+
+        if otu is None:
+            raise ValueError(f"OTU does not exist: {otu_id}")
+
+        return otu.plan
 
     def exclude_accessions(
         self,
@@ -408,6 +422,9 @@ class Repo:
     ) -> set[str]:
         """Add accessions to OTU's excluded accessions."""
         otu = self.get_otu(otu_id)
+
+        if otu is None:
+            raise ValueError(f"OTU does not exist: {otu_id}")
 
         try:
             excludable_accessions = {
@@ -457,7 +474,12 @@ class Repo:
         else:
             logger.warning("No excludable accessions were given.")
 
-        return self.get_otu(otu_id).excluded_accessions
+        updated_otu = self.get_otu(otu_id)
+
+        if updated_otu is None:
+            raise ValueError(f"OTU does not exist: {otu_id}")
+
+        return updated_otu.excluded_accessions
 
     def allow_accessions(
         self,
@@ -466,6 +488,9 @@ class Repo:
     ) -> set[str]:
         """Remove accessions from OTU's excluded accessions."""
         otu = self.get_otu(otu_id)
+
+        if otu is None:
+            raise ValueError(f"OTU does not exist: {otu_id}")
 
         allowable_accessions = set(accessions)
 
@@ -494,7 +519,12 @@ class Repo:
                 new_excluded_accessions=sorted(allowable_accessions),
             )
 
-        return self.get_otu(otu_id).excluded_accessions
+        updated_otu = self.get_otu(otu_id)
+
+        if updated_otu is None:
+            raise ValueError(f"OTU does not exist: {otu_id}")
+
+        return updated_otu.excluded_accessions
 
     def get_otu_id_by_isolate_id(self, isolate_id: uuid.UUID) -> uuid.UUID | None:
         """Get an OTU ID from an isolate ID that belongs to it."""
@@ -582,7 +612,12 @@ class Repo:
     def get_isolate(self, isolate_id: uuid.UUID) -> Isolate | None:
         """Return the isolate with the given id if it exists, else None."""
         if otu_id := self.get_otu_id_by_isolate_id(isolate_id):
-            return self.get_otu(otu_id).get_isolate(isolate_id)
+            otu = self.get_otu(otu_id)
+
+            if otu is None:
+                raise ValueError(f"OTU does not exist: {otu_id}")
+
+            return otu.get_isolate(isolate_id)
 
         return None
 

--- a/ref_builder/services/isolate.py
+++ b/ref_builder/services/isolate.py
@@ -108,6 +108,11 @@ class IsolateService(Service):
 
             if promoted_accessions:
                 otu = self._repo.get_otu(otu.id)
+
+                if otu is None:
+                    log.error("OTU disappeared after promotion")
+                    return None
+
                 # Find the isolate by one of the promoted accessions
                 promoted_accession = next(iter(promoted_accessions))
                 isolate = otu.get_isolate_by_accession(promoted_accession)
@@ -177,6 +182,10 @@ class IsolateService(Service):
             return False
 
         otu = self._repo.get_otu(otu_id)
+
+        if otu is None:
+            logger.error("OTU not found for isolate", isolate_id=str(isolate_id))
+            return False
 
         log = logger.bind(otu_id=str(otu.id), taxid=otu.taxid)
 

--- a/ref_builder/services/otu.py
+++ b/ref_builder/services/otu.py
@@ -425,12 +425,20 @@ class OTUService(Service):
         if self._promote_accessions(otu):
             otu = self._repo.get_otu(otu.id)
 
+            if otu is None:
+                log.error("OTU disappeared after promotion")
+                return None
+
         # Step 2: Upgrade outdated sequence versions
         upgraded_accessions = self._upgrade_outdated_sequences(otu)
 
         if upgraded_accessions:
             log.info("Upgraded sequences", count=len(upgraded_accessions))
             otu = self._repo.get_otu(otu.id)
+
+            if otu is None:
+                log.error("OTU disappeared after sequence upgrade")
+                return None
 
         # Step 3: Add new isolates
         accessions = self.ncbi.fetch_accessions_by_taxid(
@@ -460,6 +468,10 @@ class OTUService(Service):
                     )
                     if promoted_accessions:
                         otu = self._repo.get_otu(otu.id)
+
+                        if otu is None:
+                            log.error("OTU disappeared after record promotion")
+                            return None
 
                 records = [
                     r

--- a/ref_builder/services/otu.py
+++ b/ref_builder/services/otu.py
@@ -350,6 +350,14 @@ class OTUService(Service):
 
         for record in records:
             outdated_sequence = otu.get_sequence(record.accession)
+
+            if outdated_sequence is None:
+                logger.error(
+                    "Outdated sequence not found in OTU",
+                    accession=record.accession,
+                )
+                continue
+
             versioned_accession = Accession.from_string(record.accession_version)
 
             segment_id = assign_segment_id_to_record(record, otu.plan)
@@ -374,6 +382,13 @@ class OTUService(Service):
                 )
                 new_sequence = otu.get_sequence(record.accession)
 
+                if new_sequence is None:
+                    logger.error(
+                        "Existing sequence not found in OTU",
+                        accession=record.accession,
+                    )
+                    continue
+
             try:
                 self._repo.update_sequence(
                     otu.id,
@@ -390,7 +405,12 @@ class OTUService(Service):
                 )
                 continue
 
-            otu = self._repo.get_otu(otu.id)
+            refreshed_otu = self._repo.get_otu(otu.id)
+
+            if refreshed_otu is None:
+                raise ValueError(f"OTU does not exist: {otu.id}")
+
+            otu = refreshed_otu
 
         if upgraded_accessions:
             logger.info(

--- a/ref_builder/services/repo.py
+++ b/ref_builder/services/repo.py
@@ -98,12 +98,22 @@ class RepoService(Service):
             if otu_records:
                 otu = self._repo.get_otu(otu_id)
 
+                if otu is None:
+                    logger.debug("No corresponding OTU found in this repo", taxid=taxid)
+                    continue
+
                 # Promote RefSeq accessions first
                 refseq_records = [r for r in otu_records if r.refseq]
                 if refseq_records and promote_otu_from_records(
                     self._repo, otu, refseq_records
                 ):
                     otu = self._repo.get_otu(otu_id)
+
+                    if otu is None:
+                        logger.debug(
+                            "No corresponding OTU found in this repo", taxid=taxid
+                        )
+                        continue
 
                 # Create isolates from records
                 for isolate_name, isolate_records in group_genbank_records_by_isolate(

--- a/ref_builder/store.py
+++ b/ref_builder/store.py
@@ -139,7 +139,6 @@ class EventStore:
             f.write(
                 orjson.dumps(
                     event.model_dump(by_alias=True, mode="json"),
-                    f,
                 ),
             )
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -86,18 +86,18 @@ def scratch_user_cache_path(files_path: Path, tmp_path: Path) -> Path:
 
 
 @pytest.fixture
-def ncbi_genbank_factory() -> NCBIGenbankFactory:
+def ncbi_genbank_factory() -> type[NCBIGenbankFactory]:
     """Fixture for a factory that generates NCBIGenbank instances."""
     return NCBIGenbankFactory
 
 
 @pytest.fixture
-def ncbi_source_factory() -> NCBISourceFactory:
+def ncbi_source_factory() -> type[NCBISourceFactory]:
     """Fixture for a factory that generates NCBISource instances."""
     return NCBISourceFactory
 
 
 @pytest.fixture
-def ncbi_taxonomy_factory() -> NCBITaxonomyFactory:
+def ncbi_taxonomy_factory() -> type[NCBITaxonomyFactory]:
     """Fixture for a factory that generates NCBITaxonomy instances."""
     return NCBITaxonomyFactory

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -7,12 +7,13 @@ from pytest_mock import MockerFixture
 
 from ref_builder.logs import configure_logger
 from ref_builder.ncbi.cache import NCBICache
-from ref_builder.ncbi.client import NCBIClient, NCBIClientProtocol
+from ref_builder.ncbi.client import NCBIClient
 from tests.fixtures.factories import (
     NCBIGenbankFactory,
     NCBISourceFactory,
     NCBITaxonomyFactory,
 )
+from tests.fixtures.mock_ncbi_client import MockNCBIClient
 
 configure_logger(True)
 
@@ -27,10 +28,8 @@ def _seed_factories() -> None:
 
 
 @pytest.fixture
-def mock_ncbi_client() -> NCBIClientProtocol:
+def mock_ncbi_client() -> MockNCBIClient:
     """A mock NCBI client with hardcoded test data."""
-    from tests.fixtures.mock_ncbi_client import MockNCBIClient
-
     return MockNCBIClient()
 
 

--- a/tests/fixtures/ncbi/models.pyi
+++ b/tests/fixtures/ncbi/models.pyi
@@ -1,7 +1,6 @@
 from dataclasses import dataclass
 from pathlib import Path
 
-
 class OTUSpec:
     refseq: list[str]
     isolates: list[list[str]]
@@ -14,52 +13,37 @@ class OTUSpec:
         isolates: list[list[str]] | None = None,
         incompatible: list[str] | None = None,
     ) -> None: ...
-
     def __set_name__(self, owner, name: str) -> None: ...
-
     @property
     def all_accessions(self) -> list[str]: ...
-
 
 @dataclass
 class OTUHandle:
     name: str
     taxid: int
 
-
 class OTURegistry:
     def __init__(self, manifest: type, data_dir: Path) -> None: ...
     def validate(self) -> None: ...
-
     @property
     def abaca_bunchy_top_virus(self) -> OTUHandle: ...
-
     @property
     def babaco_mosaic_virus(self) -> OTUHandle: ...
-
     @property
     def beet_black_scorch_virus(self) -> OTUHandle: ...
-
     @property
     def cabbage_leaf_curl_jamaica_virus(self) -> OTUHandle: ...
-
     @property
     def dahlia_latent_viroid(self) -> OTUHandle: ...
-
     @property
     def east_african_cassava_mosaic_cameroon_virus(self) -> OTUHandle: ...
-
     @property
     def oat_blue_dwarf_virus(self) -> OTUHandle: ...
-
     @property
     def okra_leaf_curl_alphasatellite(self) -> OTUHandle: ...
-
     @property
     def saccharum_streak_virus(self) -> OTUHandle: ...
-
     @property
     def tobacco_mosaic_virus(self) -> OTUHandle: ...
-
     @property
     def wasabi_mottle_virus(self) -> OTUHandle: ...

--- a/tests/fixtures/ncbi/models.pyi
+++ b/tests/fixtures/ncbi/models.pyi
@@ -1,4 +1,6 @@
 from dataclasses import dataclass
+from pathlib import Path
+
 
 class OTUSpec:
     refseq: list[str]
@@ -12,35 +14,52 @@ class OTUSpec:
         isolates: list[list[str]] | None = None,
         incompatible: list[str] | None = None,
     ) -> None: ...
+
     def __set_name__(self, owner, name: str) -> None: ...
+
     @property
     def all_accessions(self) -> list[str]: ...
+
 
 @dataclass
 class OTUHandle:
     name: str
     taxid: int
 
+
 class OTURegistry:
+    def __init__(self, manifest: type, data_dir: Path) -> None: ...
+    def validate(self) -> None: ...
+
     @property
     def abaca_bunchy_top_virus(self) -> OTUHandle: ...
+
     @property
     def babaco_mosaic_virus(self) -> OTUHandle: ...
+
     @property
     def beet_black_scorch_virus(self) -> OTUHandle: ...
+
     @property
     def cabbage_leaf_curl_jamaica_virus(self) -> OTUHandle: ...
+
     @property
     def dahlia_latent_viroid(self) -> OTUHandle: ...
+
     @property
     def east_african_cassava_mosaic_cameroon_virus(self) -> OTUHandle: ...
+
     @property
     def oat_blue_dwarf_virus(self) -> OTUHandle: ...
+
     @property
     def okra_leaf_curl_alphasatellite(self) -> OTUHandle: ...
+
     @property
     def saccharum_streak_virus(self) -> OTUHandle: ...
+
     @property
     def tobacco_mosaic_virus(self) -> OTUHandle: ...
+
     @property
     def wasabi_mottle_virus(self) -> OTUHandle: ...

--- a/tests/ncbi/test_cache.py
+++ b/tests/ncbi/test_cache.py
@@ -41,6 +41,8 @@ class TestGenbank:
 
         record = scratch_ncbi_cache.load_genbank_record(accession.key)
 
+        assert record is not None
+
         scratch_ncbi_cache.clear()
 
         assert scratch_ncbi_cache.load_genbank_record(accession.key) is None
@@ -84,6 +86,8 @@ class TestTaxonomy:
     ):
         """Test that a taxonomy record can be loaded and cached correctly."""
         record = scratch_ncbi_cache.load_taxonomy(1198450)
+
+        assert record is not None
 
         scratch_ncbi_cache.clear()
 

--- a/tests/ncbi/test_model.py
+++ b/tests/ncbi/test_model.py
@@ -82,6 +82,8 @@ class TestParseTaxonomy:
         """
         record = scratch_ncbi_cache.load_taxonomy(1016856)
 
+        assert record is not None
+
         assert NCBITaxonomy.model_validate(record).rank == NCBIRank.NO_RANK
 
         taxonomy = NCBITaxonomy.model_validate({"rank": NCBIRank.ISOLATE, **record})

--- a/tests/test_build_fasta.py
+++ b/tests/test_build_fasta.py
@@ -50,6 +50,7 @@ class TestBuildFasta:
             "otu_id",
             "isolate_id",
         }
+        assert reader.fieldnames is not None
         assert set(reader.fieldnames) == expected_columns
 
     def test_no_csv(self, scratch_repo: Repo, tmp_path: Path):

--- a/tests/test_console.py
+++ b/tests/test_console.py
@@ -7,7 +7,6 @@ from ref_builder.console import (
     print_otu_list,
 )
 from ref_builder.models.otu import OTUMinimal
-from ref_builder.ncbi.client import NCBIClientProtocol
 from ref_builder.repo import Repo
 from tests.fixtures.mock_ncbi_client import MockNCBIClient
 
@@ -82,7 +81,7 @@ class TestPrintOTU:
 
     def test_ok(
         self,
-        mock_ncbi_client: NCBIClientProtocol,
+        mock_ncbi_client: MockNCBIClient,
         scratch_repo: Repo,
     ):
         """Test that an OTU is printed as expected by ``print_otu``."""

--- a/tests/test_factories.py
+++ b/tests/test_factories.py
@@ -1,7 +1,6 @@
 """Tests for data factories used in testing."""
 
 import uuid
-from uuid import uuid4
 
 from syrupy.assertion import SnapshotAssertion
 
@@ -30,7 +29,6 @@ def test_ncbi_genbank_factory(
 
     assert [
         Sequence(
-            id=uuid4(),
             accession=Accession.from_string(record.accession_version),
             definition=record.definition,
             segment=uuid.uuid4(),
@@ -145,7 +143,12 @@ class TestNCBIGenbankFactoryBuildIsolate:
         assert len(records) == 30
 
         # Verify keys go up to 30
-        segment_keys = [record.source.segment.split()[-1] for record in records]
+        assert all(record.source.segment is not None for record in records)
+        segment_keys = [
+            record.source.segment.split()[-1]
+            for record in records
+            if record.source.segment is not None
+        ]
         assert segment_keys[-1] == "30"
         assert segment_keys[0] == "1"
 
@@ -161,7 +164,11 @@ class TestNCBIGenbankFactoryBuildIsolate:
             segment_delimiter="-",
         )
 
-        assert all(record.source.segment.startswith("DNA-") for record in records)
+        assert all(
+            record.source.segment is not None
+            and record.source.segment.startswith("DNA-")
+            for record in records
+        )
 
         # Test RNA
         base_source = NCBISourceFactory.build(mol_type=NCBISourceMolType.GENOMIC_RNA)
@@ -171,7 +178,11 @@ class TestNCBIGenbankFactoryBuildIsolate:
             segment_delimiter="-",
         )
 
-        assert all(record.source.segment.startswith("RNA-") for record in records)
+        assert all(
+            record.source.segment is not None
+            and record.source.segment.startswith("RNA-")
+            for record in records
+        )
 
     def test_snapshot(
         self,

--- a/tests/test_repo.py
+++ b/tests/test_repo.py
@@ -819,6 +819,7 @@ class TestExcludeAccessions:
             )
 
         otu = initialized_repo.get_otu_by_taxid(3432891)
+        assert otu is not None
         assert len(otu.isolates) == 2
         assert len(otu.excluded_isolates) == 0
 
@@ -1054,6 +1055,7 @@ class TestAllowAccessions:
             )
 
         otu = initialized_repo.get_otu_by_taxid(3432891)
+        assert otu is not None
         assert len(otu.isolates) == 2
         assert len(otu.excluded_isolates) == 0
 
@@ -1063,6 +1065,7 @@ class TestAllowAccessions:
             initialized_repo.exclude_accessions(otu.id, {accession_to_exclude})
 
         otu = initialized_repo.get_otu_by_taxid(3432891)
+        assert otu is not None
         assert len(otu.isolates) == 1
         assert len(otu.excluded_isolates) == 1
         assert accession_to_exclude in otu.excluded_accessions
@@ -1073,6 +1076,7 @@ class TestAllowAccessions:
             initialized_repo.allow_accessions(otu.id, [accession_to_exclude])
 
         otu = initialized_repo.get_otu_by_taxid(3432891)
+        assert otu is not None
 
         # Verify the isolate is restored
         assert len(otu.isolates) == 2

--- a/uv.lock
+++ b/uv.lock
@@ -142,15 +142,6 @@ wheels = [
 ]
 
 [[package]]
-name = "nodeenv"
-version = "1.9.1"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/43/16/fc88b08840de0e0a72a2f9d8c6bae36be573e475a6326ae854bcc549fc45/nodeenv-1.9.1.tar.gz", hash = "sha256:6ec12890a2dab7946721edbfbcd91f3319c6ccc9aec47be7c7e6b7011ee6645f", size = 47437, upload-time = "2024-06-04T18:44:11.171Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/d2/1d/1b658dbd2b9fa9c4c9f32accbfc0205d532c8c6194dc0f2a4c0428e7128a/nodeenv-1.9.1-py2.py3-none-any.whl", hash = "sha256:ba11c9782d29c27c70ffbdda2d7415098754709be8a7056d79a737cd901155c9", size = 22314, upload-time = "2024-06-04T18:44:08.352Z" },
-]
-
-[[package]]
 name = "numpy"
 version = "2.3.3"
 source = { registry = "https://pypi.org/simple" }
@@ -294,19 +285,6 @@ wheels = [
 ]
 
 [[package]]
-name = "pyright"
-version = "1.1.408"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "nodeenv" },
-    { name = "typing-extensions" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/74/b2/5db700e52554b8f025faa9c3c624c59f1f6c8841ba81ab97641b54322f16/pyright-1.1.408.tar.gz", hash = "sha256:f28f2321f96852fa50b5829ea492f6adb0e6954568d1caa3f3af3a5f555eb684", size = 4400578, upload-time = "2026-01-08T08:07:38.795Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/0c/82/a2c93e32800940d9573fb28c346772a14778b84ba7524e691b324620ab89/pyright-1.1.408-py3-none-any.whl", hash = "sha256:090b32865f4fdb1e0e6cd82bf5618480d48eecd2eb2e70f960982a3d9a4c17c1", size = 6399144, upload-time = "2026-01-08T08:07:37.082Z" },
-]
-
-[[package]]
 name = "pytest"
 version = "9.0.3"
 source = { registry = "https://pypi.org/simple" }
@@ -378,12 +356,12 @@ dependencies = [
 [package.dev-dependencies]
 dev = [
     { name = "polyfactory" },
-    { name = "pyright" },
     { name = "pytest" },
     { name = "pytest-mock" },
     { name = "pytest-structlog" },
     { name = "ruff" },
     { name = "syrupy" },
+    { name = "ty" },
 ]
 
 [package.metadata]
@@ -402,12 +380,12 @@ requires-dist = [
 [package.metadata.requires-dev]
 dev = [
     { name = "polyfactory", specifier = ">=2.22.2" },
-    { name = "pyright", specifier = ">=1.1.405" },
     { name = "pytest", specifier = ">=8.4.2" },
     { name = "pytest-mock", specifier = ">=3.15.1" },
     { name = "pytest-structlog", specifier = ">=1.2" },
     { name = "ruff", specifier = ">=0.13.2" },
     { name = "syrupy", specifier = ">=4.9.1" },
+    { name = "ty", specifier = ">=0.0.42" },
 ]
 
 [[package]]
@@ -491,6 +469,31 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/3d/34/bf26c59efb44a722c57377aa903f58ef370d068466ea013977b4f2df9f6f/syrupy-5.3.1.tar.gz", hash = "sha256:449fb2997176e4ccae0e852ce23748239e1a224b4797a63173da02d6df682340", size = 83987, upload-time = "2026-05-31T18:07:44.095Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/d4/f4/753003ddb0d43247febecd5146391a59b80f77e462b2623396192180f4ee/syrupy-5.3.1-py3-none-any.whl", hash = "sha256:d755c2bb9b78692de1db5efa7b452ebff727df3a8290f740bda5c55a4ea5d7d5", size = 51985, upload-time = "2026-05-31T18:07:42.711Z" },
+]
+
+[[package]]
+name = "ty"
+version = "0.0.42"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/d8/91/5b5ec4ed8721c18be8d9611778d7c07723cd755676f03b41bf0ea0caa5d3/ty-0.0.42.tar.gz", hash = "sha256:70f5553ac678fc63558d4d77b08a18a68a228f44be2a2fe1afc3f5988db662e7", size = 5769116, upload-time = "2026-06-01T19:40:32.869Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d4/7c/2df5136ad7c0db69a3973b0b19da8f52bfacdc453c7dffc832d1bf7d23ff/ty-0.0.42-py3-none-linux_armv6l.whl", hash = "sha256:c08a0066610c13627b7d7ad758adb96ca99685791e641eb26837e20803851c53", size = 11544141, upload-time = "2026-06-01T19:40:41.065Z" },
+    { url = "https://files.pythonhosted.org/packages/0a/82/96cf406d39d8976e825361a27e332224445812793060ac9506d8a5d32b39/ty-0.0.42-py3-none-macosx_10_12_x86_64.whl", hash = "sha256:3e944ee4e3d5cdaf70e4ea87f9dd474cc3db612837b50a3ce57afa8da400ecc2", size = 11283538, upload-time = "2026-06-01T19:40:26.758Z" },
+    { url = "https://files.pythonhosted.org/packages/dc/fe/813b60b9332df835c16c05859ff5aac1896593d01b638ba0e461ede415ac/ty-0.0.42-py3-none-macosx_11_0_arm64.whl", hash = "sha256:603085306e4aac2ce592b39119a4b49ebf8b780cd394e2cfc7dbf3fd8228f954", size = 10711874, upload-time = "2026-06-01T19:40:28.77Z" },
+    { url = "https://files.pythonhosted.org/packages/07/64/1f609265be0302ce0f51aa03a27636d018947a76100ff1405258d8445e6c/ty-0.0.42-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:a58f17834d7f078c49326a01111a5aac16c979a774b98cdfd8e2350068316676", size = 11213021, upload-time = "2026-06-01T19:40:45.01Z" },
+    { url = "https://files.pythonhosted.org/packages/88/c0/f147b2fde7cd01b5f77682937e85a5cdfe35f48b3f1d0f41021024cbd927/ty-0.0.42-py3-none-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:e6ed1027f313202c5c74e376007d1eb5d214494299beb0ea047078b8ad307d40", size = 11321604, upload-time = "2026-06-01T19:40:55.164Z" },
+    { url = "https://files.pythonhosted.org/packages/a9/72/74a5e68a9bd194681f15c4aac7a0dfab378e76e7a107e8ecd93971a22377/ty-0.0.42-py3-none-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:063838d2360c1d2c065b45ca76a56ecd6df07fff6570813e74183236559e16d9", size = 11802178, upload-time = "2026-06-01T19:40:19.558Z" },
+    { url = "https://files.pythonhosted.org/packages/3c/9f/06a31dc9cc91faa2cb8a4bf2f0ba5f7a9a96a4828fb8434338682954ca86/ty-0.0.42-py3-none-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:c3f9ed508dfae4cbc943d7766324dd9c57ac8302c8543505fc29cae8ed425fe9", size = 12358436, upload-time = "2026-06-01T19:40:48.968Z" },
+    { url = "https://files.pythonhosted.org/packages/06/33/a5bb1afcb671e0b9197f007264682b22f1063bf0e83c151eeaf9958f9047/ty-0.0.42-py3-none-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:0fe1eb7d98472ac56ac19fec51c6ed8fe56d86ea0d232a11a127e8c62c882a66", size = 11997849, upload-time = "2026-06-01T19:40:42.951Z" },
+    { url = "https://files.pythonhosted.org/packages/ee/8d/560e4ec4c2f69e68fa094bb93cd19b5eb92c9732d2e0f5e7cc3accde84c4/ty-0.0.42-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:de75f9e78bfa81209f2f297528758977cfd4518ba35ef45a0acb516c892a27a5", size = 11869087, upload-time = "2026-06-01T19:40:24.38Z" },
+    { url = "https://files.pythonhosted.org/packages/b2/dd/3794db15199c03eda60961690046a56c4fbf5d8ef073c82fe2402c851b8c/ty-0.0.42-py3-none-manylinux_2_31_riscv64.whl", hash = "sha256:c63281f2f1d4df339117fcd4a6dfe17cb999f84eafe707b30e9ebbe26f0bb54a", size = 12059000, upload-time = "2026-06-01T19:40:34.982Z" },
+    { url = "https://files.pythonhosted.org/packages/98/9a/02b61cc65ecbd90f18bd02178845c5b756c78fb92643571e77df52c6eed8/ty-0.0.42-py3-none-musllinux_1_2_aarch64.whl", hash = "sha256:19e3856477f25255f772851fa7f16f5356c4e1927324d074d49c7bc9a9b211e1", size = 11195698, upload-time = "2026-06-01T19:40:37.109Z" },
+    { url = "https://files.pythonhosted.org/packages/7b/d6/3927335c956b06a806269dcd2e5b46bc4284b0a95ecc6b0246094a1de28c/ty-0.0.42-py3-none-musllinux_1_2_armv7l.whl", hash = "sha256:2f0f4acac9028264cee5ea0b88229df0b9b2586fc917dbadb6ee35a0e99e8b06", size = 11353487, upload-time = "2026-06-01T19:40:47.035Z" },
+    { url = "https://files.pythonhosted.org/packages/d6/87/79e7ae4f5f9fb3bea5f3cfac2b4f8c60e905f13962e3c0d97f8b51a5bff6/ty-0.0.42-py3-none-musllinux_1_2_i686.whl", hash = "sha256:ae244c84e30fdf2bb1a3cbf2b973da8aa535e57c701f12db44b2939604586c04", size = 11463474, upload-time = "2026-06-01T19:40:30.812Z" },
+    { url = "https://files.pythonhosted.org/packages/49/f9/73305ead1b3ccc3d79c04258877db2cd7908c6a6c2060d4e598deca384d2/ty-0.0.42-py3-none-musllinux_1_2_x86_64.whl", hash = "sha256:2430434f4a52bec0da552ff6a061dcc1c5d11973259248679a1146d776c12f37", size = 11961710, upload-time = "2026-06-01T19:40:39.056Z" },
+    { url = "https://files.pythonhosted.org/packages/e1/04/52b7325dad8d1a86653f90240208f3e3657bed5e3c8144eed367a0f736b0/ty-0.0.42-py3-none-win32.whl", hash = "sha256:984a55c2fe63b40dac03f5a144b99033c7ed720eb7611787e3f0bd49af8dcf12", size = 10783897, upload-time = "2026-06-01T19:40:22.189Z" },
+    { url = "https://files.pythonhosted.org/packages/94/d2/3d2d61255c76c0843766f00b39290115c23cc1cd4fcb0471d84a48f482f1/ty-0.0.42-py3-none-win_amd64.whl", hash = "sha256:f7afd81b10b377d9d4ce6aad355a4f47fd37d47f443118c01ca6e79d46fe6608", size = 11878640, upload-time = "2026-06-01T19:40:50.903Z" },
+    { url = "https://files.pythonhosted.org/packages/b4/91/1eb0c1e3d558707ead7424f8bfd89b58f42e576714cbed7ad46dcceef34a/ty-0.0.42-py3-none-win_arm64.whl", hash = "sha256:4068c24b0b264fc9f1901e06b97988a041fcaa36c90f18d7747f05124701c7b3", size = 11202335, upload-time = "2026-06-01T19:40:53.155Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

- Replaces `pyright` with `ty` as the project type checker (dev dependency swap in `pyproject.toml` and `uv.lock`)
- Fixes all type errors surfaced by `ty`: guarded `None`-returning getters with explicit checks/raises, corrected `@computed_field`/`@property` decorator ordering, annotated structlog processor list, fixed `log_http_error` return type to `Iterator[None]`, resolved a walrus-operator bug in `ncbi/client.py`, and added `fetch_lineage` to `NCBIClientProtocol`
- Adds a standalone `dev stub` CLI command to regenerate the mock OTU registry type stub without hitting NCBI, and refactors `_generate_stub` out of `refresh`

## Test plan

- [ ] Run `uv run ty check` and confirm zero errors
- [ ] Run the full test suite (`uv run pytest`) and confirm it passes
- [ ] Run `ref-builder dev stub` and verify `tests/fixtures/ncbi/models.pyi` is regenerated correctly
- [ ] Run `ref-builder dev refresh` and verify the stub is still written at the end of a refresh run